### PR TITLE
Add deprecated decorator for tensor methods

### DIFF
--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -54,6 +54,7 @@ from torchgen.utils import FileManager
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+DEPRECATED_TENSOR_METHODS = {"triangular_solve": "Use torch.linalg.solve_triangular instead", "matrix_power": "Use torch.linalg.matrix_power instead"}
 
 def get_py_torch_functions(
     python_funcs: Sequence[PythonSignatureNativeFunctionPair],
@@ -1638,6 +1639,8 @@ def gen_pyi(
 
     tensor_method_hints = []
     for name, hints in sorted(unsorted_tensor_method_hints.items()):
+        if name in DEPRECATED_TENSOR_METHODS: # must be before @overload
+            hints = ["@deprecated('" + DEPRECATED_TENSOR_METHODS[name] + "')\n" + h for h in hints]
         if len(hints) > 1:
             hints = ["@overload\n" + h for h in hints]
         docstr = docstrs.get(f"torch._C.TensorBase.{name}")

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -19,7 +19,7 @@ from typing import (
     SupportsIndex,
     TypeVar,
 )
-from typing_extensions import ParamSpec, Protocol, runtime_checkable, Self, TypeAlias
+from typing_extensions import ParamSpec, Protocol, runtime_checkable, Self, TypeAlias, deprecated
 
 import numpy
 

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from copy import deepcopy
 from numbers import Number
 from typing import Any, Callable, cast, Optional, TypeVar, Union
-from typing_extensions import Concatenate, ParamSpec
+from typing_extensions import Concatenate, ParamSpec, deprecated
 
 import torch
 import torch._C as _C
@@ -870,21 +870,26 @@ class Tensor(torch._C.TensorBase):
             )
         return torch.norm(self, p, dim, keepdim, dtype=dtype)
 
+    @deprecated("Use torch.linalg.solve instead", category=None)
     def solve(self, other):
         from torch._linalg_utils import solve
 
         return solve(self, other)
 
+    @deprecated("Use torch.linalg.lstsq instead", category=None)
     def lstsq(self, other):
         from torch._linalg_utils import lstsq
 
         return lstsq(self, other)
 
+    @deprecated("Use torch.linalg.eig instead", category=None)
     def eig(self, eigenvectors=False):
         from torch._linalg_utils import eig
 
         return eig(self, eigenvectors=eigenvectors)
 
+
+    @deprecated("Use torch.linalg.eigvalsh or torch.linalg.eigh instead", category=None)
     def symeig(self, eigenvectors=False):
         from torch._linalg_utils import _symeig
 


### PR DESCRIPTION
_**WIP:** Still several more methods to decorate_

This adds the `deprecated` decorator to all relevant methods on `torch.Tensor`, leading to an improved IDE experience (strike-through on the affected methods).
