### PR TITLE
Tidy tensor type stubs

### DIFF
--- a/diff_pyright_type_sym_classes_tidy_tensor_stubs.diff
+++ b/diff_pyright_type_sym_classes_tidy_tensor_stubs.diff
@@ -1,0 +1,20103 @@
+3c3
+<     "time": "1755707361009",
+---
+>     "time": "1755713518503",
+10c10
+<         "timeInSec": 8.975
+---
+>         "timeInSec": 8.865
+20,22c20,22
+<             "withKnownType": 6349,
+<             "withAmbiguousType": 820,
+<             "withUnknownType": 8835
+---
+>             "withKnownType": 6426,
+>             "withAmbiguousType": 821,
+>             "withUnknownType": 8693
+25c25
+<             "withKnownType": 2841,
+---
+>             "withKnownType": 2849,
+27c27
+<             "withUnknownType": 2221
+---
+>             "withUnknownType": 2152
+29,30c29,30
+<         "missingFunctionDocStringCount": 3950,
+<         "missingClassDocStringCount": 1078,
+---
+>         "missingFunctionDocStringCount": 3919,
+>         "missingClassDocStringCount": 1071,
+32c32
+<         "completenessScore": 0.3967133216695826,
+---
+>         "completenessScore": 0.40313676286072775,
+2645c2645
+<                                 "line": 394,
+---
+>                                 "line": 403,
+2649c2649
+<                                 "line": 394,
+---
+>                                 "line": 403,
+2703a2704,2712
+>                 "referenceCount": 2,
+>                 "isExported": true,
+>                 "isTypeKnown": true,
+>                 "isTypeAmbiguous": false,
+>                 "diagnostics": []
+>             },
+>             {
+>                 "category": "type alias",
+>                 "name": "torch.NestedList",
+2728c2737
+<                 "referenceCount": 372,
+---
+>                 "referenceCount": 365,
+2802c2811
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+2817c2826
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+2889c2898
+<                                 "line": 141,
+---
+>                                 "line": 145,
+2893c2902
+<                                 "line": 141,
+---
+>                                 "line": 145,
+2914c2923
+<                                 "line": 142,
+---
+>                                 "line": 146,
+2918c2927
+<                                 "line": 142,
+---
+>                                 "line": 146,
+2939c2948
+<                                 "line": 143,
+---
+>                                 "line": 147,
+2943c2952
+<                                 "line": 143,
+---
+>                                 "line": 147,
+3009c3018
+<                                 "line": 165,
+---
+>                                 "line": 169,
+3013c3022
+<                                 "line": 165,
+---
+>                                 "line": 169,
+3034c3043
+<                                 "line": 166,
+---
+>                                 "line": 170,
+3038c3047
+<                                 "line": 166,
+---
+>                                 "line": 170,
+3059c3068
+<                                 "line": 167,
+---
+>                                 "line": 171,
+3063c3072
+<                                 "line": 167,
+---
+>                                 "line": 171,
+3084c3093
+<                                 "line": 168,
+---
+>                                 "line": 172,
+3088c3097
+<                                 "line": 168,
+---
+>                                 "line": 172,
+3109c3118
+<                                 "line": 169,
+---
+>                                 "line": 173,
+3113c3122
+<                                 "line": 169,
+---
+>                                 "line": 173,
+3134c3143
+<                                 "line": 170,
+---
+>                                 "line": 174,
+3138c3147
+<                                 "line": 170,
+---
+>                                 "line": 174,
+3159c3168
+<                                 "line": 171,
+---
+>                                 "line": 175,
+3163c3172
+<                                 "line": 171,
+---
+>                                 "line": 175,
+3184c3193
+<                                 "line": 144,
+---
+>                                 "line": 148,
+3188c3197
+<                                 "line": 144,
+---
+>                                 "line": 148,
+3209c3218
+<                                 "line": 145,
+---
+>                                 "line": 149,
+3213c3222
+<                                 "line": 145,
+---
+>                                 "line": 149,
+3252c3261
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+3254,3300c3263
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"exc_type\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 149,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 149,
+<                                 "character": 16
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"exc_val\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 149,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 149,
+<                                 "character": 16
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"exc_tb\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 149,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 149,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+3410c3373
+<                                 "line": 186,
+---
+>                                 "line": 190,
+3414c3377
+<                                 "line": 186,
+---
+>                                 "line": 190,
+3439c3402
+<                 "referenceCount": 372,
+---
+>                 "referenceCount": 370,
+3545c3508
+<                                 "line": 195,
+---
+>                                 "line": 199,
+3549c3512
+<                                 "line": 195,
+---
+>                                 "line": 199,
+3570c3533
+<                                 "line": 196,
+---
+>                                 "line": 200,
+3574c3537
+<                                 "line": 196,
+---
+>                                 "line": 200,
+4563c4526
+<                                 "line": 327,
+---
+>                                 "line": 331,
+4567c4530
+<                                 "line": 327,
+---
+>                                 "line": 331,
+4588c4551
+<                                 "line": 328,
+---
+>                                 "line": 332,
+4592c4555
+<                                 "line": 328,
+---
+>                                 "line": 332,
+4613c4576
+<                                 "line": 329,
+---
+>                                 "line": 333,
+4617c4580
+<                                 "line": 329,
+---
+>                                 "line": 333,
+4638c4601
+<                                 "line": 330,
+---
+>                                 "line": 334,
+4642c4605
+<                                 "line": 330,
+---
+>                                 "line": 334,
+4663c4626
+<                                 "line": 331,
+---
+>                                 "line": 335,
+4667c4630
+<                                 "line": 331,
+---
+>                                 "line": 335,
+4688c4651
+<                                 "line": 332,
+---
+>                                 "line": 336,
+4692c4655
+<                                 "line": 332,
+---
+>                                 "line": 336,
+4872c4835
+<                                 "line": 12638,
+---
+>                                 "line": 12642,
+4876c4839
+<                                 "line": 12638,
+---
+>                                 "line": 12642,
+4897c4860
+<                                 "line": 12639,
+---
+>                                 "line": 12643,
+4901c4864
+<                                 "line": 12639,
+---
+>                                 "line": 12643,
+4922c4885
+<                                 "line": 12640,
+---
+>                                 "line": 12644,
+4926c4889
+<                                 "line": 12640,
+---
+>                                 "line": 12644,
+4947c4910
+<                                 "line": 12641,
+---
+>                                 "line": 12645,
+4951c4914
+<                                 "line": 12641,
+---
+>                                 "line": 12645,
+4972c4935
+<                                 "line": 12642,
+---
+>                                 "line": 12646,
+4976c4939
+<                                 "line": 12642,
+---
+>                                 "line": 12646,
+4997c4960
+<                                 "line": 12643,
+---
+>                                 "line": 12647,
+5001c4964
+<                                 "line": 12643,
+---
+>                                 "line": 12647,
+5022c4985
+<                                 "line": 12644,
+---
+>                                 "line": 12648,
+5026c4989
+<                                 "line": 12644,
+---
+>                                 "line": 12648,
+5160c5123
+<                                 "line": 926,
+---
+>                                 "line": 930,
+5164c5127
+<                                 "line": 926,
+---
+>                                 "line": 930,
+5185c5148
+<                                 "line": 927,
+---
+>                                 "line": 931,
+5189c5152
+<                                 "line": 927,
+---
+>                                 "line": 931,
+5210c5173
+<                                 "line": 928,
+---
+>                                 "line": 932,
+5214c5177
+<                                 "line": 928,
+---
+>                                 "line": 932,
+5235c5198
+<                                 "line": 929,
+---
+>                                 "line": 933,
+5239c5202
+<                                 "line": 929,
+---
+>                                 "line": 933,
+5250c5213
+<                                 "line": 929,
+---
+>                                 "line": 933,
+5254c5217
+<                                 "line": 929,
+---
+>                                 "line": 933,
+5302c5265
+<                                 "line": 845,
+---
+>                                 "line": 849,
+5306c5269
+<                                 "line": 845,
+---
+>                                 "line": 849,
+5327c5290
+<                                 "line": 846,
+---
+>                                 "line": 850,
+5331c5294
+<                                 "line": 846,
+---
+>                                 "line": 850,
+5342c5305
+<                                 "line": 846,
+---
+>                                 "line": 850,
+5346c5309
+<                                 "line": 846,
+---
+>                                 "line": 850,
+5385c5348
+<                                 "line": 813,
+---
+>                                 "line": 817,
+5389c5352
+<                                 "line": 813,
+---
+>                                 "line": 817,
+5410c5373
+<                                 "line": 814,
+---
+>                                 "line": 818,
+5414c5377
+<                                 "line": 814,
+---
+>                                 "line": 818,
+5435c5398
+<                                 "line": 815,
+---
+>                                 "line": 819,
+5439c5402
+<                                 "line": 815,
+---
+>                                 "line": 819,
+5460c5423
+<                                 "line": 816,
+---
+>                                 "line": 820,
+5464c5427
+<                                 "line": 816,
+---
+>                                 "line": 820,
+5475c5438
+<                                 "line": 816,
+---
+>                                 "line": 820,
+5479c5442
+<                                 "line": 816,
+---
+>                                 "line": 820,
+8029c7992
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+8038c8001
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+8071c8034
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+8073,8089c8036
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/autograd/graph.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"dict[Unknown, Unknown]\"\n    Type argument 1 for class \"dict\" has unknown type\n    Type argument 2 for class \"dict\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 68,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 68,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+8096c8043
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+8098,8114c8045
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/autograd/graph.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 82,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 82,
+<                                 "character": 21
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+8121c8052
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+8166c8097
+<                                 "line": 34,
+---
+>                                 "line": 39,
+8170c8101
+<                                 "line": 34,
+---
+>                                 "line": 39,
+8182c8113
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+8184,8200c8115
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/utils/hooks.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 44,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 44,
+<                                 "character": 20
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+8207c8122
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+8209,8225c8124
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/utils/hooks.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"state\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 50,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 50,
+<                                 "character": 20
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+8246c8145
+<                 "category": "variable",
+---
+>                 "category": "type alias",
+8250c8149
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+8252,8328c8151
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/utils/hooks.py",
+<                         "severity": "error",
+<                         "message": "Type is missing type annotation and could be inferred differently by type checkers\n  Inferred type is \"ReferenceType[Any]\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 55,
+<                                 "character": 17
+<                             },
+<                             "end": {
+<                                 "line": 55,
+<                                 "character": 31
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/utils/hooks.py",
+<                         "severity": "error",
+<                         "message": "Type is missing type annotation and could be inferred differently by type checkers\n  Inferred type is \"ReferenceType[OrderedDict[Unknown, Unknown]]\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 55,
+<                                 "character": 17
+<                             },
+<                             "end": {
+<                                 "line": 55,
+<                                 "character": 31
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/utils/hooks.py",
+<                         "severity": "error",
+<                         "message": "Type argument 1 for class \"ReferenceType\" has partially unknown type\n  Type is [object Object]",
+<                         "range": {
+<                             "start": {
+<                                 "line": 55,
+<                                 "character": 17
+<                             },
+<                             "end": {
+<                                 "line": 55,
+<                                 "character": 31
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/utils/hooks.py",
+<                         "severity": "error",
+<                         "message": "Type is missing type annotation and could be inferred differently by type checkers\n  Inferred type is \"ReferenceType[Unknown]\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 55,
+<                                 "character": 17
+<                             },
+<                             "end": {
+<                                 "line": 55,
+<                                 "character": 31
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/utils/hooks.py",
+<                         "severity": "error",
+<                         "message": "Type argument 1 for class \"ReferenceType\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 55,
+<                                 "character": 17
+<                             },
+<                             "end": {
+<                                 "line": 55,
+<                                 "character": 31
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+8335c8158
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+8337,8353c8160
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/utils/hooks.py",
+<                         "severity": "error",
+<                         "message": "Type argument 1 for class \"tuple\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 62,
+<                                 "character": 17
+<                             },
+<                             "end": {
+<                                 "line": 62,
+<                                 "character": 31
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+8360c8167
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+8362,8378c8169
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/autograd/graph.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 127,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 127,
+<                                 "character": 24
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+8430c8221
+<                                 "line": 2144,
+---
+>                                 "line": 2148,
+8434c8225
+<                                 "line": 2144,
+---
+>                                 "line": 2148,
+8455c8246
+<                                 "line": 2145,
+---
+>                                 "line": 2149,
+8459c8250
+<                                 "line": 2145,
+---
+>                                 "line": 2149,
+8470c8261
+<                                 "line": 2145,
+---
+>                                 "line": 2149,
+8474c8265
+<                                 "line": 2145,
+---
+>                                 "line": 2149,
+8495c8286
+<                                 "line": 2151,
+---
+>                                 "line": 2155,
+8499c8290
+<                                 "line": 2151,
+---
+>                                 "line": 2155,
+8510c8301
+<                                 "line": 2151,
+---
+>                                 "line": 2155,
+8514c8305
+<                                 "line": 2151,
+---
+>                                 "line": 2155,
+8525c8316
+<                                 "line": 2151,
+---
+>                                 "line": 2155,
+8529c8320
+<                                 "line": 2151,
+---
+>                                 "line": 2155,
+8540c8331
+<                                 "line": 2151,
+---
+>                                 "line": 2155,
+8544c8335
+<                                 "line": 2151,
+---
+>                                 "line": 2155,
+8555c8346
+<                                 "line": 2151,
+---
+>                                 "line": 2155,
+8559c8350
+<                                 "line": 2151,
+---
+>                                 "line": 2155,
+8607c8398
+<                                 "line": 2155,
+---
+>                                 "line": 2159,
+8611c8402
+<                                 "line": 2155,
+---
+>                                 "line": 2159,
+8622c8413
+<                                 "line": 2155,
+---
+>                                 "line": 2159,
+8626c8417
+<                                 "line": 2155,
+---
+>                                 "line": 2159,
+8647c8438
+<                                 "line": 2159,
+---
+>                                 "line": 2163,
+8651c8442
+<                                 "line": 2159,
+---
+>                                 "line": 2163,
+8662c8453
+<                                 "line": 2159,
+---
+>                                 "line": 2163,
+8666c8457
+<                                 "line": 2159,
+---
+>                                 "line": 2163,
+8696c8487
+<                                 "line": 2161,
+---
+>                                 "line": 2165,
+8700c8491
+<                                 "line": 2161,
+---
+>                                 "line": 2165,
+8711c8502
+<                                 "line": 2161,
+---
+>                                 "line": 2165,
+8715c8506
+<                                 "line": 2161,
+---
+>                                 "line": 2165,
+8736c8527
+<                                 "line": 2162,
+---
+>                                 "line": 2166,
+8740c8531
+<                                 "line": 2162,
+---
+>                                 "line": 2166,
+8751c8542
+<                                 "line": 2162,
+---
+>                                 "line": 2166,
+8755c8546
+<                                 "line": 2162,
+---
+>                                 "line": 2166,
+8776c8567
+<                                 "line": 2163,
+---
+>                                 "line": 2167,
+8780c8571
+<                                 "line": 2163,
+---
+>                                 "line": 2167,
+8791c8582
+<                                 "line": 2163,
+---
+>                                 "line": 2167,
+8795c8586
+<                                 "line": 2163,
+---
+>                                 "line": 2167,
+8870c8661
+<                                 "line": 91,
+---
+>                                 "line": 95,
+8874c8665
+<                                 "line": 91,
+---
+>                                 "line": 95,
+8895c8686
+<                                 "line": 92,
+---
+>                                 "line": 96,
+8899c8690
+<                                 "line": 92,
+---
+>                                 "line": 96,
+8920c8711
+<                                 "line": 2164,
+---
+>                                 "line": 2168,
+8924c8715
+<                                 "line": 2164,
+---
+>                                 "line": 2168,
+8935c8726
+<                                 "line": 2164,
+---
+>                                 "line": 2168,
+8939c8730
+<                                 "line": 2164,
+---
+>                                 "line": 2168,
+8960c8751
+<                                 "line": 2165,
+---
+>                                 "line": 2169,
+8964c8755
+<                                 "line": 2165,
+---
+>                                 "line": 2169,
+8975c8766
+<                                 "line": 2165,
+---
+>                                 "line": 2169,
+8979c8770
+<                                 "line": 2165,
+---
+>                                 "line": 2169,
+9000c8791
+<                                 "line": 2171,
+---
+>                                 "line": 2175,
+9004c8795
+<                                 "line": 2171,
+---
+>                                 "line": 2175,
+9015c8806
+<                                 "line": 2171,
+---
+>                                 "line": 2175,
+9019c8810
+<                                 "line": 2171,
+---
+>                                 "line": 2175,
+9030c8821
+<                                 "line": 2171,
+---
+>                                 "line": 2175,
+9034c8825
+<                                 "line": 2171,
+---
+>                                 "line": 2175,
+9045c8836
+<                                 "line": 2171,
+---
+>                                 "line": 2175,
+9049c8840
+<                                 "line": 2171,
+---
+>                                 "line": 2175,
+9060c8851
+<                                 "line": 2171,
+---
+>                                 "line": 2175,
+9064c8855
+<                                 "line": 2171,
+---
+>                                 "line": 2175,
+9085c8876
+<                                 "line": 2172,
+---
+>                                 "line": 2176,
+9089c8880
+<                                 "line": 2172,
+---
+>                                 "line": 2176,
+9100c8891
+<                                 "line": 2172,
+---
+>                                 "line": 2176,
+9104c8895
+<                                 "line": 2172,
+---
+>                                 "line": 2176,
+9125c8916
+<                                 "line": 2173,
+---
+>                                 "line": 2177,
+9129c8920
+<                                 "line": 2173,
+---
+>                                 "line": 2177,
+9140c8931
+<                                 "line": 2173,
+---
+>                                 "line": 2177,
+9144c8935
+<                                 "line": 2173,
+---
+>                                 "line": 2177,
+9165c8956
+<                                 "line": 2179,
+---
+>                                 "line": 2183,
+9169c8960
+<                                 "line": 2179,
+---
+>                                 "line": 2183,
+9180c8971
+<                                 "line": 2179,
+---
+>                                 "line": 2183,
+9184c8975
+<                                 "line": 2179,
+---
+>                                 "line": 2183,
+9195c8986
+<                                 "line": 2179,
+---
+>                                 "line": 2183,
+9199c8990
+<                                 "line": 2179,
+---
+>                                 "line": 2183,
+9210c9001
+<                                 "line": 2179,
+---
+>                                 "line": 2183,
+9214c9005
+<                                 "line": 2179,
+---
+>                                 "line": 2183,
+9225c9016
+<                                 "line": 2179,
+---
+>                                 "line": 2183,
+9229c9020
+<                                 "line": 2179,
+---
+>                                 "line": 2183,
+9250c9041
+<                                 "line": 2180,
+---
+>                                 "line": 2184,
+9254c9045
+<                                 "line": 2180,
+---
+>                                 "line": 2184,
+9265c9056
+<                                 "line": 2180,
+---
+>                                 "line": 2184,
+9269c9060
+<                                 "line": 2180,
+---
+>                                 "line": 2184,
+9290c9081
+<                                 "line": 2181,
+---
+>                                 "line": 2185,
+9294c9085
+<                                 "line": 2181,
+---
+>                                 "line": 2185,
+9305c9096
+<                                 "line": 2181,
+---
+>                                 "line": 2185,
+9309c9100
+<                                 "line": 2181,
+---
+>                                 "line": 2185,
+9339c9130
+<                                 "line": 2194,
+---
+>                                 "line": 2198,
+9343c9134
+<                                 "line": 2194,
+---
+>                                 "line": 2198,
+9590c9381
+<                                 "line": 2201,
+---
+>                                 "line": 2205,
+9594c9385
+<                                 "line": 2201,
+---
+>                                 "line": 2205,
+9615c9406
+<                                 "line": 2207,
+---
+>                                 "line": 2211,
+9619c9410
+<                                 "line": 2207,
+---
+>                                 "line": 2211,
+9630c9421
+<                                 "line": 2207,
+---
+>                                 "line": 2211,
+9634c9425
+<                                 "line": 2207,
+---
+>                                 "line": 2211,
+9645c9436
+<                                 "line": 2207,
+---
+>                                 "line": 2211,
+9649c9440
+<                                 "line": 2207,
+---
+>                                 "line": 2211,
+9660c9451
+<                                 "line": 2207,
+---
+>                                 "line": 2211,
+9664c9455
+<                                 "line": 2207,
+---
+>                                 "line": 2211,
+9675c9466
+<                                 "line": 2207,
+---
+>                                 "line": 2211,
+9679c9470
+<                                 "line": 2207,
+---
+>                                 "line": 2211,
+9700c9491
+<                                 "line": 2213,
+---
+>                                 "line": 2217,
+9704c9495
+<                                 "line": 2213,
+---
+>                                 "line": 2217,
+9715c9506
+<                                 "line": 2213,
+---
+>                                 "line": 2217,
+9719c9510
+<                                 "line": 2213,
+---
+>                                 "line": 2217,
+9730c9521
+<                                 "line": 2213,
+---
+>                                 "line": 2217,
+9734c9525
+<                                 "line": 2213,
+---
+>                                 "line": 2217,
+9745c9536
+<                                 "line": 2213,
+---
+>                                 "line": 2217,
+9749c9540
+<                                 "line": 2213,
+---
+>                                 "line": 2217,
+9760c9551
+<                                 "line": 2213,
+---
+>                                 "line": 2217,
+9764c9555
+<                                 "line": 2213,
+---
+>                                 "line": 2217,
+9785c9576
+<                                 "line": 2214,
+---
+>                                 "line": 2218,
+9789c9580
+<                                 "line": 2214,
+---
+>                                 "line": 2218,
+9800c9591
+<                                 "line": 2214,
+---
+>                                 "line": 2218,
+9804c9595
+<                                 "line": 2214,
+---
+>                                 "line": 2218,
+9825c9616
+<                                 "line": 2220,
+---
+>                                 "line": 2224,
+9829c9620
+<                                 "line": 2220,
+---
+>                                 "line": 2224,
+9840c9631
+<                                 "line": 2220,
+---
+>                                 "line": 2224,
+9844c9635
+<                                 "line": 2220,
+---
+>                                 "line": 2224,
+9855c9646
+<                                 "line": 2220,
+---
+>                                 "line": 2224,
+9859c9650
+<                                 "line": 2220,
+---
+>                                 "line": 2224,
+9870c9661
+<                                 "line": 2220,
+---
+>                                 "line": 2224,
+9874c9665
+<                                 "line": 2220,
+---
+>                                 "line": 2224,
+9885c9676
+<                                 "line": 2220,
+---
+>                                 "line": 2224,
+9889c9680
+<                                 "line": 2220,
+---
+>                                 "line": 2224,
+9910c9701
+<                                 "line": 2221,
+---
+>                                 "line": 2225,
+9914c9705
+<                                 "line": 2221,
+---
+>                                 "line": 2225,
+9925c9716
+<                                 "line": 2221,
+---
+>                                 "line": 2225,
+9929c9720
+<                                 "line": 2221,
+---
+>                                 "line": 2225,
+9959c9750
+<                                 "line": 2228,
+---
+>                                 "line": 2232,
+9963c9754
+<                                 "line": 2228,
+---
+>                                 "line": 2232,
+9974c9765
+<                                 "line": 2228,
+---
+>                                 "line": 2232,
+9978c9769
+<                                 "line": 2228,
+---
+>                                 "line": 2232,
+9989c9780
+<                                 "line": 2228,
+---
+>                                 "line": 2232,
+9993c9784
+<                                 "line": 2228,
+---
+>                                 "line": 2232,
+10004c9795
+<                                 "line": 2228,
+---
+>                                 "line": 2232,
+10008c9799
+<                                 "line": 2228,
+---
+>                                 "line": 2232,
+10019c9810
+<                                 "line": 2228,
+---
+>                                 "line": 2232,
+10023c9814
+<                                 "line": 2228,
+---
+>                                 "line": 2232,
+10044c9835
+<                                 "line": 2229,
+---
+>                                 "line": 2233,
+10048c9839
+<                                 "line": 2229,
+---
+>                                 "line": 2233,
+10059c9850
+<                                 "line": 2229,
+---
+>                                 "line": 2233,
+10063c9854
+<                                 "line": 2229,
+---
+>                                 "line": 2233,
+10084c9875
+<                                 "line": 2230,
+---
+>                                 "line": 2234,
+10088c9879
+<                                 "line": 2230,
+---
+>                                 "line": 2234,
+10099c9890
+<                                 "line": 2230,
+---
+>                                 "line": 2234,
+10103c9894
+<                                 "line": 2230,
+---
+>                                 "line": 2234,
+10124c9915
+<                                 "line": 2231,
+---
+>                                 "line": 2235,
+10128c9919
+<                                 "line": 2231,
+---
+>                                 "line": 2235,
+10139c9930
+<                                 "line": 2231,
+---
+>                                 "line": 2235,
+10143c9934
+<                                 "line": 2231,
+---
+>                                 "line": 2235,
+10164c9955
+<                                 "line": 2232,
+---
+>                                 "line": 2236,
+10168c9959
+<                                 "line": 2232,
+---
+>                                 "line": 2236,
+10179c9970
+<                                 "line": 2232,
+---
+>                                 "line": 2236,
+10183c9974
+<                                 "line": 2232,
+---
+>                                 "line": 2236,
+10204c9995
+<                                 "line": 2236,
+---
+>                                 "line": 2240,
+10208c9999
+<                                 "line": 2236,
+---
+>                                 "line": 2240,
+10219c10010
+<                                 "line": 2236,
+---
+>                                 "line": 2240,
+10223c10014
+<                                 "line": 2236,
+---
+>                                 "line": 2240,
+10244c10035
+<                                 "line": 2237,
+---
+>                                 "line": 2241,
+10248c10039
+<                                 "line": 2237,
+---
+>                                 "line": 2241,
+10260c10051
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+10262,10293c10053
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"args\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 2238,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 2238,
+<                                 "character": 15
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"kwargs\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 2238,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 2238,
+<                                 "character": 15
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+10318c10078
+<                                 "line": 2245,
+---
+>                                 "line": 2249,
+10322c10082
+<                                 "line": 2245,
+---
+>                                 "line": 2249,
+10333c10093
+<                                 "line": 2245,
+---
+>                                 "line": 2249,
+10337c10097
+<                                 "line": 2245,
+---
+>                                 "line": 2249,
+10348c10108
+<                                 "line": 2245,
+---
+>                                 "line": 2249,
+10352c10112
+<                                 "line": 2245,
+---
+>                                 "line": 2249,
+10363c10123
+<                                 "line": 2245,
+---
+>                                 "line": 2249,
+10367c10127
+<                                 "line": 2245,
+---
+>                                 "line": 2249,
+10378c10138
+<                                 "line": 2245,
+---
+>                                 "line": 2249,
+10382c10142
+<                                 "line": 2245,
+---
+>                                 "line": 2249,
+10403c10163
+<                                 "line": 2246,
+---
+>                                 "line": 2250,
+10407c10167
+<                                 "line": 2246,
+---
+>                                 "line": 2250,
+10418c10178
+<                                 "line": 2246,
+---
+>                                 "line": 2250,
+10422c10182
+<                                 "line": 2246,
+---
+>                                 "line": 2250,
+10443c10203
+<                                 "line": 2247,
+---
+>                                 "line": 2251,
+10447c10207
+<                                 "line": 2247,
+---
+>                                 "line": 2251,
+10458c10218
+<                                 "line": 2247,
+---
+>                                 "line": 2251,
+10462c10222
+<                                 "line": 2247,
+---
+>                                 "line": 2251,
+10483c10243
+<                                 "line": 2248,
+---
+>                                 "line": 2252,
+10487c10247
+<                                 "line": 2248,
+---
+>                                 "line": 2252,
+10498c10258
+<                                 "line": 2248,
+---
+>                                 "line": 2252,
+10502c10262
+<                                 "line": 2248,
+---
+>                                 "line": 2252,
+10523c10283
+<                                 "line": 2249,
+---
+>                                 "line": 2253,
+10527c10287
+<                                 "line": 2249,
+---
+>                                 "line": 2253,
+10538c10298
+<                                 "line": 2249,
+---
+>                                 "line": 2253,
+10542c10302
+<                                 "line": 2249,
+---
+>                                 "line": 2253,
+10563c10323
+<                                 "line": 2250,
+---
+>                                 "line": 2254,
+10567c10327
+<                                 "line": 2250,
+---
+>                                 "line": 2254,
+10578c10338
+<                                 "line": 2250,
+---
+>                                 "line": 2254,
+10582c10342
+<                                 "line": 2250,
+---
+>                                 "line": 2254,
+10603c10363
+<                                 "line": 2251,
+---
+>                                 "line": 2255,
+10607c10367
+<                                 "line": 2251,
+---
+>                                 "line": 2255,
+10618c10378
+<                                 "line": 2251,
+---
+>                                 "line": 2255,
+10622c10382
+<                                 "line": 2251,
+---
+>                                 "line": 2255,
+10643c10403
+<                                 "line": 2252,
+---
+>                                 "line": 2256,
+10647c10407
+<                                 "line": 2252,
+---
+>                                 "line": 2256,
+10658c10418
+<                                 "line": 2252,
+---
+>                                 "line": 2256,
+10662c10422
+<                                 "line": 2252,
+---
+>                                 "line": 2256,
+10683c10443
+<                                 "line": 2258,
+---
+>                                 "line": 2262,
+10687c10447
+<                                 "line": 2258,
+---
+>                                 "line": 2262,
+10698c10458
+<                                 "line": 2258,
+---
+>                                 "line": 2262,
+10702c10462
+<                                 "line": 2258,
+---
+>                                 "line": 2262,
+10713c10473
+<                                 "line": 2258,
+---
+>                                 "line": 2262,
+10717c10477
+<                                 "line": 2258,
+---
+>                                 "line": 2262,
+10728c10488
+<                                 "line": 2258,
+---
+>                                 "line": 2262,
+10732c10492
+<                                 "line": 2258,
+---
+>                                 "line": 2262,
+10743c10503
+<                                 "line": 2258,
+---
+>                                 "line": 2262,
+10747c10507
+<                                 "line": 2258,
+---
+>                                 "line": 2262,
+10768c10528
+<                                 "line": 2259,
+---
+>                                 "line": 2263,
+10772c10532
+<                                 "line": 2259,
+---
+>                                 "line": 2263,
+10783c10543
+<                                 "line": 2259,
+---
+>                                 "line": 2263,
+10787c10547
+<                                 "line": 2259,
+---
+>                                 "line": 2263,
+10808c10568
+<                                 "line": 2260,
+---
+>                                 "line": 2264,
+10812c10572
+<                                 "line": 2260,
+---
+>                                 "line": 2264,
+10823c10583
+<                                 "line": 2260,
+---
+>                                 "line": 2264,
+10827c10587
+<                                 "line": 2260,
+---
+>                                 "line": 2264,
+10848c10608
+<                                 "line": 2261,
+---
+>                                 "line": 2265,
+10852c10612
+<                                 "line": 2261,
+---
+>                                 "line": 2265,
+10863c10623
+<                                 "line": 2261,
+---
+>                                 "line": 2265,
+10867c10627
+<                                 "line": 2261,
+---
+>                                 "line": 2265,
+10888c10648
+<                                 "line": 2262,
+---
+>                                 "line": 2266,
+10892c10652
+<                                 "line": 2262,
+---
+>                                 "line": 2266,
+10903c10663
+<                                 "line": 2262,
+---
+>                                 "line": 2266,
+10907c10667
+<                                 "line": 2262,
+---
+>                                 "line": 2266,
+10928c10688
+<                                 "line": 2268,
+---
+>                                 "line": 2272,
+10932c10692
+<                                 "line": 2268,
+---
+>                                 "line": 2272,
+10943c10703
+<                                 "line": 2268,
+---
+>                                 "line": 2272,
+10947c10707
+<                                 "line": 2268,
+---
+>                                 "line": 2272,
+10968c10728
+<                                 "line": 2269,
+---
+>                                 "line": 2273,
+10972c10732
+<                                 "line": 2269,
+---
+>                                 "line": 2273,
+10983c10743
+<                                 "line": 2269,
+---
+>                                 "line": 2273,
+10987c10747
+<                                 "line": 2269,
+---
+>                                 "line": 2273,
+11008c10768
+<                                 "line": 2275,
+---
+>                                 "line": 2279,
+11012c10772
+<                                 "line": 2275,
+---
+>                                 "line": 2279,
+11023c10783
+<                                 "line": 2275,
+---
+>                                 "line": 2279,
+11027c10787
+<                                 "line": 2275,
+---
+>                                 "line": 2279,
+11038c10798
+<                                 "line": 2275,
+---
+>                                 "line": 2279,
+11042c10802
+<                                 "line": 2275,
+---
+>                                 "line": 2279,
+11053c10813
+<                                 "line": 2275,
+---
+>                                 "line": 2279,
+11057c10817
+<                                 "line": 2275,
+---
+>                                 "line": 2279,
+11068c10828
+<                                 "line": 2275,
+---
+>                                 "line": 2279,
+11072c10832
+<                                 "line": 2275,
+---
+>                                 "line": 2279,
+11093c10853
+<                                 "line": 2373,
+---
+>                                 "line": 2377,
+11097c10857
+<                                 "line": 2373,
+---
+>                                 "line": 2377,
+11118c10878
+<                                 "line": 2380,
+---
+>                                 "line": 2384,
+11122c10882
+<                                 "line": 2380,
+---
+>                                 "line": 2384,
+11143c10903
+<                                 "line": 2387,
+---
+>                                 "line": 2391,
+11147c10907
+<                                 "line": 2387,
+---
+>                                 "line": 2391,
+11168c10928
+<                                 "line": 2394,
+---
+>                                 "line": 2398,
+11172c10932
+<                                 "line": 2394,
+---
+>                                 "line": 2398,
+11193c10953
+<                                 "line": 2402,
+---
+>                                 "line": 2406,
+11197c10957
+<                                 "line": 2402,
+---
+>                                 "line": 2406,
+11218c10978
+<                                 "line": 2409,
+---
+>                                 "line": 2413,
+11222c10982
+<                                 "line": 2409,
+---
+>                                 "line": 2413,
+11243c11003
+<                                 "line": 2416,
+---
+>                                 "line": 2420,
+11247c11007
+<                                 "line": 2416,
+---
+>                                 "line": 2420,
+11268c11028
+<                                 "line": 2423,
+---
+>                                 "line": 2427,
+11272c11032
+<                                 "line": 2423,
+---
+>                                 "line": 2427,
+11293c11053
+<                                 "line": 2430,
+---
+>                                 "line": 2434,
+11297c11057
+<                                 "line": 2430,
+---
+>                                 "line": 2434,
+11308c11068
+<                                 "line": 2430,
+---
+>                                 "line": 2434,
+11312c11072
+<                                 "line": 2430,
+---
+>                                 "line": 2434,
+11323c11083
+<                                 "line": 2430,
+---
+>                                 "line": 2434,
+11327c11087
+<                                 "line": 2430,
+---
+>                                 "line": 2434,
+12086c11846
+<                                 "line": 724,
+---
+>                                 "line": 737,
+12090c11850
+<                                 "line": 724,
+---
+>                                 "line": 737,
+12111c11871
+<                                 "line": 731,
+---
+>                                 "line": 744,
+12115c11875
+<                                 "line": 731,
+---
+>                                 "line": 744,
+12145c11905
+<                                 "line": 2451,
+---
+>                                 "line": 2455,
+12149c11909
+<                                 "line": 2451,
+---
+>                                 "line": 2455,
+12160c11920
+<                                 "line": 2451,
+---
+>                                 "line": 2455,
+12164c11924
+<                                 "line": 2451,
+---
+>                                 "line": 2455,
+12185c11945
+<                                 "line": 2463,
+---
+>                                 "line": 2467,
+12189c11949
+<                                 "line": 2463,
+---
+>                                 "line": 2467,
+12200c11960
+<                                 "line": 2463,
+---
+>                                 "line": 2467,
+12204c11964
+<                                 "line": 2463,
+---
+>                                 "line": 2467,
+12215c11975
+<                                 "line": 2463,
+---
+>                                 "line": 2467,
+12219c11979
+<                                 "line": 2463,
+---
+>                                 "line": 2467,
+12240c12000
+<                                 "line": 2477,
+---
+>                                 "line": 2481,
+12244c12004
+<                                 "line": 2477,
+---
+>                                 "line": 2481,
+12255c12015
+<                                 "line": 2477,
+---
+>                                 "line": 2481,
+12259c12019
+<                                 "line": 2477,
+---
+>                                 "line": 2481,
+12270c12030
+<                                 "line": 2477,
+---
+>                                 "line": 2481,
+12274c12034
+<                                 "line": 2477,
+---
+>                                 "line": 2481,
+12295c12055
+<                                 "line": 2491,
+---
+>                                 "line": 2495,
+12299c12059
+<                                 "line": 2491,
+---
+>                                 "line": 2495,
+12310c12070
+<                                 "line": 2491,
+---
+>                                 "line": 2495,
+12314c12074
+<                                 "line": 2491,
+---
+>                                 "line": 2495,
+12325c12085
+<                                 "line": 2491,
+---
+>                                 "line": 2495,
+12329c12089
+<                                 "line": 2491,
+---
+>                                 "line": 2495,
+12350c12110
+<                                 "line": 2504,
+---
+>                                 "line": 2508,
+12354c12114
+<                                 "line": 2504,
+---
+>                                 "line": 2508,
+12365c12125
+<                                 "line": 2504,
+---
+>                                 "line": 2508,
+12369c12129
+<                                 "line": 2504,
+---
+>                                 "line": 2508,
+12380c12140
+<                                 "line": 2504,
+---
+>                                 "line": 2508,
+12384c12144
+<                                 "line": 2504,
+---
+>                                 "line": 2508,
+12405c12165
+<                                 "line": 2517,
+---
+>                                 "line": 2521,
+12409c12169
+<                                 "line": 2517,
+---
+>                                 "line": 2521,
+12420c12180
+<                                 "line": 2517,
+---
+>                                 "line": 2521,
+12424c12184
+<                                 "line": 2517,
+---
+>                                 "line": 2521,
+12435c12195
+<                                 "line": 2517,
+---
+>                                 "line": 2521,
+12439c12199
+<                                 "line": 2517,
+---
+>                                 "line": 2521,
+12460c12220
+<                                 "line": 2530,
+---
+>                                 "line": 2534,
+12464c12224
+<                                 "line": 2530,
+---
+>                                 "line": 2534,
+12475c12235
+<                                 "line": 2530,
+---
+>                                 "line": 2534,
+12479c12239
+<                                 "line": 2530,
+---
+>                                 "line": 2534,
+12490c12250
+<                                 "line": 2530,
+---
+>                                 "line": 2534,
+12494c12254
+<                                 "line": 2530,
+---
+>                                 "line": 2534,
+12515c12275
+<                                 "line": 2543,
+---
+>                                 "line": 2547,
+12519c12279
+<                                 "line": 2543,
+---
+>                                 "line": 2547,
+12530c12290
+<                                 "line": 2543,
+---
+>                                 "line": 2547,
+12534c12294
+<                                 "line": 2543,
+---
+>                                 "line": 2547,
+12545c12305
+<                                 "line": 2543,
+---
+>                                 "line": 2547,
+12549c12309
+<                                 "line": 2543,
+---
+>                                 "line": 2547,
+12570c12330
+<                                 "line": 2557,
+---
+>                                 "line": 2561,
+12574c12334
+<                                 "line": 2557,
+---
+>                                 "line": 2561,
+12585c12345
+<                                 "line": 2557,
+---
+>                                 "line": 2561,
+12589c12349
+<                                 "line": 2557,
+---
+>                                 "line": 2561,
+12600c12360
+<                                 "line": 2557,
+---
+>                                 "line": 2561,
+12604c12364
+<                                 "line": 2557,
+---
+>                                 "line": 2561,
+12625c12385
+<                                 "line": 2571,
+---
+>                                 "line": 2575,
+12629c12389
+<                                 "line": 2571,
+---
+>                                 "line": 2575,
+12640c12400
+<                                 "line": 2571,
+---
+>                                 "line": 2575,
+12644c12404
+<                                 "line": 2571,
+---
+>                                 "line": 2575,
+12655c12415
+<                                 "line": 2571,
+---
+>                                 "line": 2575,
+12659c12419
+<                                 "line": 2571,
+---
+>                                 "line": 2575,
+12680c12440
+<                                 "line": 2585,
+---
+>                                 "line": 2589,
+12684c12444
+<                                 "line": 2585,
+---
+>                                 "line": 2589,
+12695c12455
+<                                 "line": 2585,
+---
+>                                 "line": 2589,
+12699c12459
+<                                 "line": 2585,
+---
+>                                 "line": 2589,
+12710c12470
+<                                 "line": 2585,
+---
+>                                 "line": 2589,
+12714c12474
+<                                 "line": 2585,
+---
+>                                 "line": 2589,
+12735c12495
+<                                 "line": 2599,
+---
+>                                 "line": 2603,
+12739c12499
+<                                 "line": 2599,
+---
+>                                 "line": 2603,
+12750c12510
+<                                 "line": 2599,
+---
+>                                 "line": 2603,
+12754c12514
+<                                 "line": 2599,
+---
+>                                 "line": 2603,
+12765c12525
+<                                 "line": 2599,
+---
+>                                 "line": 2603,
+12769c12529
+<                                 "line": 2599,
+---
+>                                 "line": 2603,
+12790c12550
+<                                 "line": 2613,
+---
+>                                 "line": 2617,
+12794c12554
+<                                 "line": 2613,
+---
+>                                 "line": 2617,
+12805c12565
+<                                 "line": 2613,
+---
+>                                 "line": 2617,
+12809c12569
+<                                 "line": 2613,
+---
+>                                 "line": 2617,
+12820c12580
+<                                 "line": 2613,
+---
+>                                 "line": 2617,
+12824c12584
+<                                 "line": 2613,
+---
+>                                 "line": 2617,
+12845c12605
+<                                 "line": 2627,
+---
+>                                 "line": 2631,
+12849c12609
+<                                 "line": 2627,
+---
+>                                 "line": 2631,
+12870c12630
+<                                 "line": 2634,
+---
+>                                 "line": 2638,
+12874c12634
+<                                 "line": 2634,
+---
+>                                 "line": 2638,
+12885c12645
+<                                 "line": 2634,
+---
+>                                 "line": 2638,
+12889c12649
+<                                 "line": 2634,
+---
+>                                 "line": 2638,
+12910c12670
+<                                 "line": 2687,
+---
+>                                 "line": 2691,
+12914c12674
+<                                 "line": 2687,
+---
+>                                 "line": 2691,
+12925c12685
+<                                 "line": 2687,
+---
+>                                 "line": 2691,
+12929c12689
+<                                 "line": 2687,
+---
+>                                 "line": 2691,
+12950c12710
+<                                 "line": 2713,
+---
+>                                 "line": 2717,
+12954c12714
+<                                 "line": 2713,
+---
+>                                 "line": 2717,
+12965c12725
+<                                 "line": 2713,
+---
+>                                 "line": 2717,
+12969c12729
+<                                 "line": 2713,
+---
+>                                 "line": 2717,
+12980c12740
+<                                 "line": 2713,
+---
+>                                 "line": 2717,
+12984c12744
+<                                 "line": 2713,
+---
+>                                 "line": 2717,
+12995c12755
+<                                 "line": 2713,
+---
+>                                 "line": 2717,
+12999c12759
+<                                 "line": 2713,
+---
+>                                 "line": 2717,
+13020c12780
+<                                 "line": 2724,
+---
+>                                 "line": 2728,
+13024c12784
+<                                 "line": 2724,
+---
+>                                 "line": 2728,
+13045c12805
+<                                 "line": 2737,
+---
+>                                 "line": 2741,
+13049c12809
+<                                 "line": 2737,
+---
+>                                 "line": 2741,
+13070c12830
+<                                 "line": 2744,
+---
+>                                 "line": 2748,
+13074c12834
+<                                 "line": 2744,
+---
+>                                 "line": 2748,
+13095c12855
+<                                 "line": 2751,
+---
+>                                 "line": 2755,
+13099c12859
+<                                 "line": 2751,
+---
+>                                 "line": 2755,
+13210c12970
+<                                 "line": 2763,
+---
+>                                 "line": 2767,
+13214c12974
+<                                 "line": 2763,
+---
+>                                 "line": 2767,
+13235c12995
+<                                 "line": 2795,
+---
+>                                 "line": 2799,
+13239c12999
+<                                 "line": 2795,
+---
+>                                 "line": 2799,
+13250c13010
+<                                 "line": 2795,
+---
+>                                 "line": 2799,
+13254c13014
+<                                 "line": 2795,
+---
+>                                 "line": 2799,
+13265c13025
+<                                 "line": 2795,
+---
+>                                 "line": 2799,
+13269c13029
+<                                 "line": 2795,
+---
+>                                 "line": 2799,
+13280c13040
+<                                 "line": 2795,
+---
+>                                 "line": 2799,
+13284c13044
+<                                 "line": 2795,
+---
+>                                 "line": 2799,
+13305c13065
+<                                 "line": 2806,
+---
+>                                 "line": 2810,
+13309c13069
+<                                 "line": 2806,
+---
+>                                 "line": 2810,
+13330c13090
+<                                 "line": 2819,
+---
+>                                 "line": 2823,
+13334c13094
+<                                 "line": 2819,
+---
+>                                 "line": 2823,
+13355c13115
+<                                 "line": 2826,
+---
+>                                 "line": 2830,
+13359c13119
+<                                 "line": 2826,
+---
+>                                 "line": 2830,
+13380c13140
+<                                 "line": 2833,
+---
+>                                 "line": 2837,
+13384c13144
+<                                 "line": 2833,
+---
+>                                 "line": 2837,
+13405c13165
+<                                 "line": 2840,
+---
+>                                 "line": 2844,
+13409c13169
+<                                 "line": 2840,
+---
+>                                 "line": 2844,
+13430c13190
+<                                 "line": 2847,
+---
+>                                 "line": 2851,
+13434c13194
+<                                 "line": 2847,
+---
+>                                 "line": 2851,
+13455c13215
+<                                 "line": 2854,
+---
+>                                 "line": 2858,
+13459c13219
+<                                 "line": 2854,
+---
+>                                 "line": 2858,
+13480c13240
+<                                 "line": 2861,
+---
+>                                 "line": 2865,
+13484c13244
+<                                 "line": 2861,
+---
+>                                 "line": 2865,
+13505c13265
+<                                 "line": 2868,
+---
+>                                 "line": 2872,
+13509c13269
+<                                 "line": 2868,
+---
+>                                 "line": 2872,
+13530c13290
+<                                 "line": 2875,
+---
+>                                 "line": 2879,
+13534c13294
+<                                 "line": 2875,
+---
+>                                 "line": 2879,
+13555c13315
+<                                 "line": 2882,
+---
+>                                 "line": 2886,
+13559c13319
+<                                 "line": 2882,
+---
+>                                 "line": 2886,
+13570c13330
+<                                 "line": 2882,
+---
+>                                 "line": 2886,
+13574c13334
+<                                 "line": 2882,
+---
+>                                 "line": 2886,
+13595c13355
+<                                 "line": 2889,
+---
+>                                 "line": 2893,
+13599c13359
+<                                 "line": 2889,
+---
+>                                 "line": 2893,
+13610c13370
+<                                 "line": 2889,
+---
+>                                 "line": 2893,
+13614c13374
+<                                 "line": 2889,
+---
+>                                 "line": 2893,
+13635c13395
+<                                 "line": 2896,
+---
+>                                 "line": 2900,
+13639c13399
+<                                 "line": 2896,
+---
+>                                 "line": 2900,
+13660c13420
+<                                 "line": 2903,
+---
+>                                 "line": 2907,
+13664c13424
+<                                 "line": 2903,
+---
+>                                 "line": 2907,
+13685c13445
+<                                 "line": 2910,
+---
+>                                 "line": 2914,
+13689c13449
+<                                 "line": 2910,
+---
+>                                 "line": 2914,
+13710c13470
+<                                 "line": 2917,
+---
+>                                 "line": 2921,
+13714c13474
+<                                 "line": 2917,
+---
+>                                 "line": 2921,
+13735c13495
+<                                 "line": 2924,
+---
+>                                 "line": 2928,
+13739c13499
+<                                 "line": 2924,
+---
+>                                 "line": 2928,
+13760c13520
+<                                 "line": 2954,
+---
+>                                 "line": 2958,
+13764c13524
+<                                 "line": 2954,
+---
+>                                 "line": 2958,
+13775c13535
+<                                 "line": 2954,
+---
+>                                 "line": 2958,
+13779c13539
+<                                 "line": 2954,
+---
+>                                 "line": 2958,
+13790c13550
+<                                 "line": 2954,
+---
+>                                 "line": 2958,
+13794c13554
+<                                 "line": 2954,
+---
+>                                 "line": 2958,
+13815c13575
+<                                 "line": 2965,
+---
+>                                 "line": 2969,
+13819c13579
+<                                 "line": 2965,
+---
+>                                 "line": 2969,
+13840c13600
+<                                 "line": 2972,
+---
+>                                 "line": 2976,
+13844c13604
+<                                 "line": 2972,
+---
+>                                 "line": 2976,
+13865c13625
+<                                 "line": 2984,
+---
+>                                 "line": 2988,
+13869c13629
+<                                 "line": 2984,
+---
+>                                 "line": 2988,
+13890c13650
+<                                 "line": 2996,
+---
+>                                 "line": 3000,
+13894c13654
+<                                 "line": 2996,
+---
+>                                 "line": 3000,
+13905c13665
+<                                 "line": 2996,
+---
+>                                 "line": 3000,
+13909c13669
+<                                 "line": 2996,
+---
+>                                 "line": 3000,
+13939c13699
+<                                 "line": 3018,
+---
+>                                 "line": 3022,
+13943c13703
+<                                 "line": 3018,
+---
+>                                 "line": 3022,
+13964c13724
+<                                 "line": 3025,
+---
+>                                 "line": 3029,
+13968c13728
+<                                 "line": 3025,
+---
+>                                 "line": 3029,
+13989c13749
+<                                 "line": 3032,
+---
+>                                 "line": 3036,
+13993c13753
+<                                 "line": 3032,
+---
+>                                 "line": 3036,
+14014c13774
+<                                 "line": 3039,
+---
+>                                 "line": 3043,
+14018c13778
+<                                 "line": 3039,
+---
+>                                 "line": 3043,
+14039c13799
+<                                 "line": 3046,
+---
+>                                 "line": 3050,
+14043c13803
+<                                 "line": 3046,
+---
+>                                 "line": 3050,
+14064c13824
+<                                 "line": 3053,
+---
+>                                 "line": 3057,
+14068c13828
+<                                 "line": 3053,
+---
+>                                 "line": 3057,
+14079c13839
+<                                 "line": 3053,
+---
+>                                 "line": 3057,
+14083c13843
+<                                 "line": 3053,
+---
+>                                 "line": 3057,
+14104c13864
+<                                 "line": 3060,
+---
+>                                 "line": 3064,
+14108c13868
+<                                 "line": 3060,
+---
+>                                 "line": 3064,
+14119c13879
+<                                 "line": 3060,
+---
+>                                 "line": 3064,
+14123c13883
+<                                 "line": 3060,
+---
+>                                 "line": 3064,
+14144c13904
+<                                 "line": 3067,
+---
+>                                 "line": 3071,
+14148c13908
+<                                 "line": 3067,
+---
+>                                 "line": 3071,
+14169c13929
+<                                 "line": 3074,
+---
+>                                 "line": 3078,
+14173c13933
+<                                 "line": 3074,
+---
+>                                 "line": 3078,
+14194c13954
+<                                 "line": 3081,
+---
+>                                 "line": 3085,
+14198c13958
+<                                 "line": 3081,
+---
+>                                 "line": 3085,
+14219c13979
+<                                 "line": 3088,
+---
+>                                 "line": 3092,
+14223c13983
+<                                 "line": 3088,
+---
+>                                 "line": 3092,
+14234c13994
+<                                 "line": 3088,
+---
+>                                 "line": 3092,
+14238c13998
+<                                 "line": 3088,
+---
+>                                 "line": 3092,
+14249c14009
+<                                 "line": 3088,
+---
+>                                 "line": 3092,
+14253c14013
+<                                 "line": 3088,
+---
+>                                 "line": 3092,
+14274c14034
+<                                 "line": 3102,
+---
+>                                 "line": 3106,
+14278c14038
+<                                 "line": 3102,
+---
+>                                 "line": 3106,
+14289c14049
+<                                 "line": 3102,
+---
+>                                 "line": 3106,
+14293c14053
+<                                 "line": 3102,
+---
+>                                 "line": 3106,
+14304c14064
+<                                 "line": 3102,
+---
+>                                 "line": 3106,
+14308c14068
+<                                 "line": 3102,
+---
+>                                 "line": 3106,
+14329c14089
+<                                 "line": 3129,
+---
+>                                 "line": 3133,
+14333c14093
+<                                 "line": 3129,
+---
+>                                 "line": 3133,
+14344c14104
+<                                 "line": 3129,
+---
+>                                 "line": 3133,
+14348c14108
+<                                 "line": 3129,
+---
+>                                 "line": 3133,
+14359c14119
+<                                 "line": 3129,
+---
+>                                 "line": 3133,
+14363c14123
+<                                 "line": 3129,
+---
+>                                 "line": 3133,
+14374c14134
+<                                 "line": 3129,
+---
+>                                 "line": 3133,
+14378c14138
+<                                 "line": 3129,
+---
+>                                 "line": 3133,
+14454c14214
+<                                 "line": 1694,
+---
+>                                 "line": 1698,
+14458c14218
+<                                 "line": 1694,
+---
+>                                 "line": 1698,
+14469c14229
+<                                 "line": 1694,
+---
+>                                 "line": 1698,
+14473c14233
+<                                 "line": 1694,
+---
+>                                 "line": 1698,
+14494c14254
+<                                 "line": 1695,
+---
+>                                 "line": 1699,
+14498c14258
+<                                 "line": 1695,
+---
+>                                 "line": 1699,
+14509c14269
+<                                 "line": 1695,
+---
+>                                 "line": 1699,
+14513c14273
+<                                 "line": 1695,
+---
+>                                 "line": 1699,
+14534c14294
+<                                 "line": 1696,
+---
+>                                 "line": 1700,
+14538c14298
+<                                 "line": 1696,
+---
+>                                 "line": 1700,
+14559c14319
+<                                 "line": 1697,
+---
+>                                 "line": 1701,
+14563c14323
+<                                 "line": 1697,
+---
+>                                 "line": 1701,
+14584c14344
+<                                 "line": 1698,
+---
+>                                 "line": 1702,
+14588c14348
+<                                 "line": 1698,
+---
+>                                 "line": 1702,
+14609c14369
+<                                 "line": 1699,
+---
+>                                 "line": 1703,
+14613c14373
+<                                 "line": 1699,
+---
+>                                 "line": 1703,
+14634c14394
+<                                 "line": 1700,
+---
+>                                 "line": 1704,
+14638c14398
+<                                 "line": 1700,
+---
+>                                 "line": 1704,
+14659c14419
+<                                 "line": 1701,
+---
+>                                 "line": 1705,
+14663c14423
+<                                 "line": 1701,
+---
+>                                 "line": 1705,
+14684c14444
+<                                 "line": 1702,
+---
+>                                 "line": 1706,
+14688c14448
+<                                 "line": 1702,
+---
+>                                 "line": 1706,
+14709c14469
+<                                 "line": 1703,
+---
+>                                 "line": 1707,
+14713c14473
+<                                 "line": 1703,
+---
+>                                 "line": 1707,
+14734c14494
+<                                 "line": 3171,
+---
+>                                 "line": 3175,
+14738c14498
+<                                 "line": 3171,
+---
+>                                 "line": 3175,
+14749c14509
+<                                 "line": 3171,
+---
+>                                 "line": 3175,
+14753c14513
+<                                 "line": 3171,
+---
+>                                 "line": 3175,
+14764c14524
+<                                 "line": 3171,
+---
+>                                 "line": 3175,
+14768c14528
+<                                 "line": 3171,
+---
+>                                 "line": 3175,
+14779c14539
+<                                 "line": 3171,
+---
+>                                 "line": 3175,
+14783c14543
+<                                 "line": 3171,
+---
+>                                 "line": 3175,
+14794c14554
+<                                 "line": 3171,
+---
+>                                 "line": 3175,
+14798c14558
+<                                 "line": 3171,
+---
+>                                 "line": 3175,
+14819c14579
+<                                 "line": 3195,
+---
+>                                 "line": 3199,
+14823c14583
+<                                 "line": 3195,
+---
+>                                 "line": 3199,
+14844c14604
+<                                 "line": 3205,
+---
+>                                 "line": 3209,
+14848c14608
+<                                 "line": 3205,
+---
+>                                 "line": 3209,
+14859c14619
+<                                 "line": 3205,
+---
+>                                 "line": 3209,
+14863c14623
+<                                 "line": 3205,
+---
+>                                 "line": 3209,
+14884c14644
+<                                 "line": 3225,
+---
+>                                 "line": 3229,
+14888c14648
+<                                 "line": 3225,
+---
+>                                 "line": 3229,
+14899c14659
+<                                 "line": 3225,
+---
+>                                 "line": 3229,
+14903c14663
+<                                 "line": 3225,
+---
+>                                 "line": 3229,
+14914c14674
+<                                 "line": 3225,
+---
+>                                 "line": 3229,
+14918c14678
+<                                 "line": 3225,
+---
+>                                 "line": 3229,
+14939c14699
+<                                 "line": 3241,
+---
+>                                 "line": 3245,
+14943c14703
+<                                 "line": 3241,
+---
+>                                 "line": 3245,
+14954c14714
+<                                 "line": 3241,
+---
+>                                 "line": 3245,
+14958c14718
+<                                 "line": 3241,
+---
+>                                 "line": 3245,
+14969c14729
+<                                 "line": 3241,
+---
+>                                 "line": 3245,
+14973c14733
+<                                 "line": 3241,
+---
+>                                 "line": 3245,
+14994c14754
+<                                 "line": 3257,
+---
+>                                 "line": 3261,
+14998c14758
+<                                 "line": 3257,
+---
+>                                 "line": 3261,
+15009c14769
+<                                 "line": 3257,
+---
+>                                 "line": 3261,
+15013c14773
+<                                 "line": 3257,
+---
+>                                 "line": 3261,
+15024c14784
+<                                 "line": 3257,
+---
+>                                 "line": 3261,
+15028c14788
+<                                 "line": 3257,
+---
+>                                 "line": 3261,
+15049c14809
+<                                 "line": 3273,
+---
+>                                 "line": 3277,
+15053c14813
+<                                 "line": 3273,
+---
+>                                 "line": 3277,
+15064c14824
+<                                 "line": 3273,
+---
+>                                 "line": 3277,
+15068c14828
+<                                 "line": 3273,
+---
+>                                 "line": 3277,
+15079c14839
+<                                 "line": 3273,
+---
+>                                 "line": 3277,
+15083c14843
+<                                 "line": 3273,
+---
+>                                 "line": 3277,
+15104c14864
+<                                 "line": 3280,
+---
+>                                 "line": 3284,
+15108c14868
+<                                 "line": 3280,
+---
+>                                 "line": 3284,
+15129c14889
+<                                 "line": 3287,
+---
+>                                 "line": 3291,
+15133c14893
+<                                 "line": 3287,
+---
+>                                 "line": 3291,
+15154c14914
+<                                 "line": 3303,
+---
+>                                 "line": 3307,
+15158c14918
+<                                 "line": 3303,
+---
+>                                 "line": 3307,
+15169c14929
+<                                 "line": 3303,
+---
+>                                 "line": 3307,
+15173c14933
+<                                 "line": 3303,
+---
+>                                 "line": 3307,
+15184c14944
+<                                 "line": 3303,
+---
+>                                 "line": 3307,
+15188c14948
+<                                 "line": 3303,
+---
+>                                 "line": 3307,
+15209c14969
+<                                 "line": 3319,
+---
+>                                 "line": 3323,
+15213c14973
+<                                 "line": 3319,
+---
+>                                 "line": 3323,
+15224c14984
+<                                 "line": 3319,
+---
+>                                 "line": 3323,
+15228c14988
+<                                 "line": 3319,
+---
+>                                 "line": 3323,
+15239c14999
+<                                 "line": 3319,
+---
+>                                 "line": 3323,
+15243c15003
+<                                 "line": 3319,
+---
+>                                 "line": 3323,
+15264c15024
+<                                 "line": 3335,
+---
+>                                 "line": 3339,
+15268c15028
+<                                 "line": 3335,
+---
+>                                 "line": 3339,
+15279c15039
+<                                 "line": 3335,
+---
+>                                 "line": 3339,
+15283c15043
+<                                 "line": 3335,
+---
+>                                 "line": 3339,
+15294c15054
+<                                 "line": 3335,
+---
+>                                 "line": 3339,
+15298c15058
+<                                 "line": 3335,
+---
+>                                 "line": 3339,
+15319c15079
+<                                 "line": 3351,
+---
+>                                 "line": 3355,
+15323c15083
+<                                 "line": 3351,
+---
+>                                 "line": 3355,
+15334c15094
+<                                 "line": 3351,
+---
+>                                 "line": 3355,
+15338c15098
+<                                 "line": 3351,
+---
+>                                 "line": 3355,
+15349c15109
+<                                 "line": 3351,
+---
+>                                 "line": 3355,
+15353c15113
+<                                 "line": 3351,
+---
+>                                 "line": 3355,
+15374c15134
+<                                 "line": 3367,
+---
+>                                 "line": 3371,
+15378c15138
+<                                 "line": 3367,
+---
+>                                 "line": 3371,
+15389c15149
+<                                 "line": 3367,
+---
+>                                 "line": 3371,
+15393c15153
+<                                 "line": 3367,
+---
+>                                 "line": 3371,
+15404c15164
+<                                 "line": 3367,
+---
+>                                 "line": 3371,
+15408c15168
+<                                 "line": 3367,
+---
+>                                 "line": 3371,
+15429c15189
+<                                 "line": 3383,
+---
+>                                 "line": 3387,
+15433c15193
+<                                 "line": 3383,
+---
+>                                 "line": 3387,
+15444c15204
+<                                 "line": 3383,
+---
+>                                 "line": 3387,
+15448c15208
+<                                 "line": 3383,
+---
+>                                 "line": 3387,
+15459c15219
+<                                 "line": 3383,
+---
+>                                 "line": 3387,
+15463c15223
+<                                 "line": 3383,
+---
+>                                 "line": 3387,
+15484c15244
+<                                 "line": 3390,
+---
+>                                 "line": 3394,
+15488c15248
+<                                 "line": 3390,
+---
+>                                 "line": 3394,
+15499c15259
+<                                 "line": 3390,
+---
+>                                 "line": 3394,
+15503c15263
+<                                 "line": 3390,
+---
+>                                 "line": 3394,
+15524c15284
+<                                 "line": 3397,
+---
+>                                 "line": 3401,
+15528c15288
+<                                 "line": 3397,
+---
+>                                 "line": 3401,
+15549c15309
+<                                 "line": 3417,
+---
+>                                 "line": 3421,
+15553c15313
+<                                 "line": 3417,
+---
+>                                 "line": 3421,
+15564c15324
+<                                 "line": 3417,
+---
+>                                 "line": 3421,
+15568c15328
+<                                 "line": 3417,
+---
+>                                 "line": 3421,
+15589c15349
+<                                 "line": 3424,
+---
+>                                 "line": 3428,
+15593c15353
+<                                 "line": 3424,
+---
+>                                 "line": 3428,
+15614c15374
+<                                 "line": 3435,
+---
+>                                 "line": 3439,
+15618c15378
+<                                 "line": 3435,
+---
+>                                 "line": 3439,
+15629c15389
+<                                 "line": 3435,
+---
+>                                 "line": 3439,
+15633c15393
+<                                 "line": 3435,
+---
+>                                 "line": 3439,
+15654c15414
+<                                 "line": 3455,
+---
+>                                 "line": 3459,
+15658c15418
+<                                 "line": 3455,
+---
+>                                 "line": 3459,
+15669c15429
+<                                 "line": 3455,
+---
+>                                 "line": 3459,
+15673c15433
+<                                 "line": 3455,
+---
+>                                 "line": 3459,
+15694c15454
+<                                 "line": 3456,
+---
+>                                 "line": 3460,
+15698c15458
+<                                 "line": 3456,
+---
+>                                 "line": 3460,
+15719c15479
+<                                 "line": 3463,
+---
+>                                 "line": 3467,
+15723c15483
+<                                 "line": 3463,
+---
+>                                 "line": 3467,
+15744c15504
+<                                 "line": 3470,
+---
+>                                 "line": 3474,
+15748c15508
+<                                 "line": 3470,
+---
+>                                 "line": 3474,
+15769c15529
+<                                 "line": 3481,
+---
+>                                 "line": 3485,
+15773c15533
+<                                 "line": 3481,
+---
+>                                 "line": 3485,
+15794c15554
+<                                 "line": 3492,
+---
+>                                 "line": 3496,
+15798c15558
+<                                 "line": 3492,
+---
+>                                 "line": 3496,
+15819c15579
+<                                 "line": 3499,
+---
+>                                 "line": 3503,
+15823c15583
+<                                 "line": 3499,
+---
+>                                 "line": 3503,
+15844c15604
+<                                 "line": 3506,
+---
+>                                 "line": 3510,
+15848c15608
+<                                 "line": 3506,
+---
+>                                 "line": 3510,
+15859c15619
+<                                 "line": 3506,
+---
+>                                 "line": 3510,
+15863c15623
+<                                 "line": 3506,
+---
+>                                 "line": 3510,
+15893c15653
+<                                 "line": 3533,
+---
+>                                 "line": 3537,
+15897c15657
+<                                 "line": 3533,
+---
+>                                 "line": 3537,
+15908c15668
+<                                 "line": 3533,
+---
+>                                 "line": 3537,
+15912c15672
+<                                 "line": 3533,
+---
+>                                 "line": 3537,
+15923c15683
+<                                 "line": 3533,
+---
+>                                 "line": 3537,
+15927c15687
+<                                 "line": 3533,
+---
+>                                 "line": 3537,
+15938c15698
+<                                 "line": 3533,
+---
+>                                 "line": 3537,
+15942c15702
+<                                 "line": 3533,
+---
+>                                 "line": 3537,
+15963c15723
+<                                 "line": 3557,
+---
+>                                 "line": 3561,
+15967c15727
+<                                 "line": 3557,
+---
+>                                 "line": 3561,
+15978c15738
+<                                 "line": 3557,
+---
+>                                 "line": 3561,
+15982c15742
+<                                 "line": 3557,
+---
+>                                 "line": 3561,
+15993c15753
+<                                 "line": 3557,
+---
+>                                 "line": 3561,
+15997c15757
+<                                 "line": 3557,
+---
+>                                 "line": 3561,
+16008c15768
+<                                 "line": 3557,
+---
+>                                 "line": 3561,
+16012c15772
+<                                 "line": 3557,
+---
+>                                 "line": 3561,
+16033c15793
+<                                 "line": 3571,
+---
+>                                 "line": 3575,
+16037c15797
+<                                 "line": 3571,
+---
+>                                 "line": 3575,
+16048c15808
+<                                 "line": 3571,
+---
+>                                 "line": 3575,
+16052c15812
+<                                 "line": 3571,
+---
+>                                 "line": 3575,
+16063c15823
+<                                 "line": 3571,
+---
+>                                 "line": 3575,
+16067c15827
+<                                 "line": 3571,
+---
+>                                 "line": 3575,
+16088c15848
+<                                 "line": 3575,
+---
+>                                 "line": 3579,
+16092c15852
+<                                 "line": 3575,
+---
+>                                 "line": 3579,
+16103c15863
+<                                 "line": 3575,
+---
+>                                 "line": 3579,
+16107c15867
+<                                 "line": 3575,
+---
+>                                 "line": 3579,
+16118c15878
+<                                 "line": 3575,
+---
+>                                 "line": 3579,
+16122c15882
+<                                 "line": 3575,
+---
+>                                 "line": 3579,
+16143c15903
+<                                 "line": 3579,
+---
+>                                 "line": 3583,
+16147c15907
+<                                 "line": 3579,
+---
+>                                 "line": 3583,
+16158c15918
+<                                 "line": 3579,
+---
+>                                 "line": 3583,
+16162c15922
+<                                 "line": 3579,
+---
+>                                 "line": 3583,
+16173c15933
+<                                 "line": 3579,
+---
+>                                 "line": 3583,
+16177c15937
+<                                 "line": 3579,
+---
+>                                 "line": 3583,
+16198c15958
+<                                 "line": 3583,
+---
+>                                 "line": 3587,
+16202c15962
+<                                 "line": 3583,
+---
+>                                 "line": 3587,
+16213c15973
+<                                 "line": 3583,
+---
+>                                 "line": 3587,
+16217c15977
+<                                 "line": 3583,
+---
+>                                 "line": 3587,
+16228c15988
+<                                 "line": 3583,
+---
+>                                 "line": 3587,
+16232c15992
+<                                 "line": 3583,
+---
+>                                 "line": 3587,
+16253c16013
+<                                 "line": 3597,
+---
+>                                 "line": 3601,
+16257c16017
+<                                 "line": 3597,
+---
+>                                 "line": 3601,
+16268c16028
+<                                 "line": 3597,
+---
+>                                 "line": 3601,
+16272c16032
+<                                 "line": 3597,
+---
+>                                 "line": 3601,
+16283c16043
+<                                 "line": 3597,
+---
+>                                 "line": 3601,
+16287c16047
+<                                 "line": 3597,
+---
+>                                 "line": 3601,
+16298c16058
+<                                 "line": 3597,
+---
+>                                 "line": 3601,
+16302c16062
+<                                 "line": 3597,
+---
+>                                 "line": 3601,
+16323c16083
+<                                 "line": 3621,
+---
+>                                 "line": 3625,
+16327c16087
+<                                 "line": 3621,
+---
+>                                 "line": 3625,
+16338c16098
+<                                 "line": 3621,
+---
+>                                 "line": 3625,
+16342c16102
+<                                 "line": 3621,
+---
+>                                 "line": 3625,
+16353c16113
+<                                 "line": 3621,
+---
+>                                 "line": 3625,
+16357c16117
+<                                 "line": 3621,
+---
+>                                 "line": 3625,
+16368c16128
+<                                 "line": 3621,
+---
+>                                 "line": 3625,
+16372c16132
+<                                 "line": 3621,
+---
+>                                 "line": 3625,
+16393c16153
+<                                 "line": 3632,
+---
+>                                 "line": 3636,
+16397c16157
+<                                 "line": 3632,
+---
+>                                 "line": 3636,
+16418c16178
+<                                 "line": 3639,
+---
+>                                 "line": 3643,
+16422c16182
+<                                 "line": 3639,
+---
+>                                 "line": 3643,
+16443c16203
+<                                 "line": 3652,
+---
+>                                 "line": 3656,
+16447c16207
+<                                 "line": 3652,
+---
+>                                 "line": 3656,
+16468c16228
+<                                 "line": 3670,
+---
+>                                 "line": 3674,
+16472c16232
+<                                 "line": 3670,
+---
+>                                 "line": 3674,
+16493c16253
+<                                 "line": 3677,
+---
+>                                 "line": 3681,
+16497c16257
+<                                 "line": 3677,
+---
+>                                 "line": 3681,
+16518c16278
+<                                 "line": 3684,
+---
+>                                 "line": 3688,
+16522c16282
+<                                 "line": 3684,
+---
+>                                 "line": 3688,
+16543c16303
+<                                 "line": 3691,
+---
+>                                 "line": 3695,
+16547c16307
+<                                 "line": 3691,
+---
+>                                 "line": 3695,
+16568c16328
+<                                 "line": 3707,
+---
+>                                 "line": 3711,
+16572c16332
+<                                 "line": 3707,
+---
+>                                 "line": 3711,
+16583c16343
+<                                 "line": 3707,
+---
+>                                 "line": 3711,
+16587c16347
+<                                 "line": 3707,
+---
+>                                 "line": 3711,
+16608c16368
+<                                 "line": 3734,
+---
+>                                 "line": 3738,
+16612c16372
+<                                 "line": 3734,
+---
+>                                 "line": 3738,
+16623c16383
+<                                 "line": 3734,
+---
+>                                 "line": 3738,
+16627c16387
+<                                 "line": 3734,
+---
+>                                 "line": 3738,
+16638c16398
+<                                 "line": 3734,
+---
+>                                 "line": 3738,
+16642c16402
+<                                 "line": 3734,
+---
+>                                 "line": 3738,
+16663c16423
+<                                 "line": 3750,
+---
+>                                 "line": 3754,
+16667c16427
+<                                 "line": 3750,
+---
+>                                 "line": 3754,
+16678c16438
+<                                 "line": 3750,
+---
+>                                 "line": 3754,
+16682c16442
+<                                 "line": 3750,
+---
+>                                 "line": 3754,
+16693c16453
+<                                 "line": 3750,
+---
+>                                 "line": 3754,
+16697c16457
+<                                 "line": 3750,
+---
+>                                 "line": 3754,
+16718c16478
+<                                 "line": 3757,
+---
+>                                 "line": 3761,
+16722c16482
+<                                 "line": 3757,
+---
+>                                 "line": 3761,
+16743c16503
+<                                 "line": 3764,
+---
+>                                 "line": 3768,
+16747c16507
+<                                 "line": 3764,
+---
+>                                 "line": 3768,
+16768c16528
+<                                 "line": 3771,
+---
+>                                 "line": 3775,
+16772c16532
+<                                 "line": 3771,
+---
+>                                 "line": 3775,
+16793c16553
+<                                 "line": 3778,
+---
+>                                 "line": 3782,
+16797c16557
+<                                 "line": 3778,
+---
+>                                 "line": 3782,
+16818c16578
+<                                 "line": 3785,
+---
+>                                 "line": 3789,
+16822c16582
+<                                 "line": 3785,
+---
+>                                 "line": 3789,
+16843c16603
+<                                 "line": 3809,
+---
+>                                 "line": 3813,
+16847c16607
+<                                 "line": 3809,
+---
+>                                 "line": 3813,
+16858c16618
+<                                 "line": 3809,
+---
+>                                 "line": 3813,
+16862c16622
+<                                 "line": 3809,
+---
+>                                 "line": 3813,
+16873c16633
+<                                 "line": 3809,
+---
+>                                 "line": 3813,
+16877c16637
+<                                 "line": 3809,
+---
+>                                 "line": 3813,
+16898c16658
+<                                 "line": 3816,
+---
+>                                 "line": 3820,
+16902c16662
+<                                 "line": 3816,
+---
+>                                 "line": 3820,
+16913c16673
+<                                 "line": 3816,
+---
+>                                 "line": 3820,
+16917c16677
+<                                 "line": 3816,
+---
+>                                 "line": 3820,
+16928c16688
+<                                 "line": 3816,
+---
+>                                 "line": 3820,
+16932c16692
+<                                 "line": 3816,
+---
+>                                 "line": 3820,
+16953c16713
+<                                 "line": 3829,
+---
+>                                 "line": 3833,
+16957c16717
+<                                 "line": 3829,
+---
+>                                 "line": 3833,
+16978c16738
+<                                 "line": 3846,
+---
+>                                 "line": 3850,
+16982c16742
+<                                 "line": 3846,
+---
+>                                 "line": 3850,
+16993c16753
+<                                 "line": 3846,
+---
+>                                 "line": 3850,
+16997c16757
+<                                 "line": 3846,
+---
+>                                 "line": 3850,
+17018c16778
+<                                 "line": 3853,
+---
+>                                 "line": 3857,
+17022c16782
+<                                 "line": 3853,
+---
+>                                 "line": 3857,
+17043c16803
+<                                 "line": 3871,
+---
+>                                 "line": 3875,
+17047c16807
+<                                 "line": 3871,
+---
+>                                 "line": 3875,
+17068c16828
+<                                 "line": 3904,
+---
+>                                 "line": 3908,
+17072c16832
+<                                 "line": 3904,
+---
+>                                 "line": 3908,
+17083c16843
+<                                 "line": 3904,
+---
+>                                 "line": 3908,
+17087c16847
+<                                 "line": 3904,
+---
+>                                 "line": 3908,
+17198c16958
+<                                 "line": 3923,
+---
+>                                 "line": 3927,
+17202c16962
+<                                 "line": 3923,
+---
+>                                 "line": 3927,
+17213c16973
+<                                 "line": 3923,
+---
+>                                 "line": 3927,
+17217c16977
+<                                 "line": 3923,
+---
+>                                 "line": 3927,
+17328c17088
+<                                 "line": 3942,
+---
+>                                 "line": 3946,
+17332c17092
+<                                 "line": 3942,
+---
+>                                 "line": 3946,
+17343c17103
+<                                 "line": 3942,
+---
+>                                 "line": 3946,
+17347c17107
+<                                 "line": 3942,
+---
+>                                 "line": 3946,
+17368c17128
+<                                 "line": 3963,
+---
+>                                 "line": 3967,
+17372c17132
+<                                 "line": 3963,
+---
+>                                 "line": 3967,
+17383c17143
+<                                 "line": 3963,
+---
+>                                 "line": 3967,
+17387c17147
+<                                 "line": 3963,
+---
+>                                 "line": 3967,
+17408c17168
+<                                 "line": 3984,
+---
+>                                 "line": 3988,
+17412c17172
+<                                 "line": 3984,
+---
+>                                 "line": 3988,
+17423c17183
+<                                 "line": 3984,
+---
+>                                 "line": 3988,
+17427c17187
+<                                 "line": 3984,
+---
+>                                 "line": 3988,
+17448c17208
+<                                 "line": 4005,
+---
+>                                 "line": 4009,
+17452c17212
+<                                 "line": 4005,
+---
+>                                 "line": 4009,
+17463c17223
+<                                 "line": 4005,
+---
+>                                 "line": 4009,
+17467c17227
+<                                 "line": 4005,
+---
+>                                 "line": 4009,
+17497c17257
+<                                 "line": 4024,
+---
+>                                 "line": 4028,
+17501c17261
+<                                 "line": 4024,
+---
+>                                 "line": 4028,
+17522c17282
+<                                 "line": 4031,
+---
+>                                 "line": 4035,
+17526c17286
+<                                 "line": 4031,
+---
+>                                 "line": 4035,
+17556c17316
+<                                 "line": 4050,
+---
+>                                 "line": 4054,
+17560c17320
+<                                 "line": 4050,
+---
+>                                 "line": 4054,
+17581c17341
+<                                 "line": 4057,
+---
+>                                 "line": 4061,
+17585c17345
+<                                 "line": 4057,
+---
+>                                 "line": 4061,
+17606c17366
+<                                 "line": 4064,
+---
+>                                 "line": 4068,
+17610c17370
+<                                 "line": 4064,
+---
+>                                 "line": 4068,
+17621c17381
+<                                 "line": 4064,
+---
+>                                 "line": 4068,
+17625c17385
+<                                 "line": 4064,
+---
+>                                 "line": 4068,
+17646c17406
+<                                 "line": 4065,
+---
+>                                 "line": 4069,
+17650c17410
+<                                 "line": 4065,
+---
+>                                 "line": 4069,
+17661c17421
+<                                 "line": 4065,
+---
+>                                 "line": 4069,
+17665c17425
+<                                 "line": 4065,
+---
+>                                 "line": 4069,
+17686c17446
+<                                 "line": 4066,
+---
+>                                 "line": 4070,
+17690c17450
+<                                 "line": 4066,
+---
+>                                 "line": 4070,
+17711c17471
+<                                 "line": 4073,
+---
+>                                 "line": 4077,
+17715c17475
+<                                 "line": 4073,
+---
+>                                 "line": 4077,
+17736c17496
+<                                 "line": 4085,
+---
+>                                 "line": 4089,
+17740c17500
+<                                 "line": 4085,
+---
+>                                 "line": 4089,
+17761c17521
+<                                 "line": 4108,
+---
+>                                 "line": 4112,
+17765c17525
+<                                 "line": 4108,
+---
+>                                 "line": 4112,
+17776c17536
+<                                 "line": 4108,
+---
+>                                 "line": 4112,
+17780c17540
+<                                 "line": 4108,
+---
+>                                 "line": 4112,
+17801c17561
+<                                 "line": 4120,
+---
+>                                 "line": 4124,
+17805c17565
+<                                 "line": 4120,
+---
+>                                 "line": 4124,
+17816c17576
+<                                 "line": 4120,
+---
+>                                 "line": 4124,
+17820c17580
+<                                 "line": 4120,
+---
+>                                 "line": 4124,
+17841c17601
+<                                 "line": 4133,
+---
+>                                 "line": 4137,
+17845c17605
+<                                 "line": 4133,
+---
+>                                 "line": 4137,
+17856c17616
+<                                 "line": 4133,
+---
+>                                 "line": 4137,
+17860c17620
+<                                 "line": 4133,
+---
+>                                 "line": 4137,
+17871c17631
+<                                 "line": 4133,
+---
+>                                 "line": 4137,
+17875c17635
+<                                 "line": 4133,
+---
+>                                 "line": 4137,
+17896c17656
+<                                 "line": 4146,
+---
+>                                 "line": 4150,
+17900c17660
+<                                 "line": 4146,
+---
+>                                 "line": 4150,
+17921c17681
+<                                 "line": 4153,
+---
+>                                 "line": 4157,
+17925c17685
+<                                 "line": 4153,
+---
+>                                 "line": 4157,
+17955c17715
+<                                 "line": 4167,
+---
+>                                 "line": 4171,
+17959c17719
+<                                 "line": 4167,
+---
+>                                 "line": 4171,
+17970c17730
+<                                 "line": 4167,
+---
+>                                 "line": 4171,
+17974c17734
+<                                 "line": 4167,
+---
+>                                 "line": 4171,
+17995c17755
+<                                 "line": 4174,
+---
+>                                 "line": 4178,
+17999c17759
+<                                 "line": 4174,
+---
+>                                 "line": 4178,
+18010c17770
+<                                 "line": 4174,
+---
+>                                 "line": 4178,
+18014c17774
+<                                 "line": 4174,
+---
+>                                 "line": 4178,
+18035c17795
+<                                 "line": 4186,
+---
+>                                 "line": 4190,
+18039c17799
+<                                 "line": 4186,
+---
+>                                 "line": 4190,
+18050c17810
+<                                 "line": 4186,
+---
+>                                 "line": 4190,
+18054c17814
+<                                 "line": 4186,
+---
+>                                 "line": 4190,
+18075c17835
+<                                 "line": 4228,
+---
+>                                 "line": 4232,
+18079c17839
+<                                 "line": 4228,
+---
+>                                 "line": 4232,
+18090c17850
+<                                 "line": 4228,
+---
+>                                 "line": 4232,
+18094c17854
+<                                 "line": 4228,
+---
+>                                 "line": 4232,
+18105c17865
+<                                 "line": 4228,
+---
+>                                 "line": 4232,
+18109c17869
+<                                 "line": 4228,
+---
+>                                 "line": 4232,
+18120c17880
+<                                 "line": 4228,
+---
+>                                 "line": 4232,
+18124c17884
+<                                 "line": 4228,
+---
+>                                 "line": 4232,
+18135c17895
+<                                 "line": 4228,
+---
+>                                 "line": 4232,
+18139c17899
+<                                 "line": 4228,
+---
+>                                 "line": 4232,
+18150c17910
+<                                 "line": 4228,
+---
+>                                 "line": 4232,
+18154c17914
+<                                 "line": 4228,
+---
+>                                 "line": 4232,
+18175c17935
+<                                 "line": 4265,
+---
+>                                 "line": 4269,
+18179c17939
+<                                 "line": 4265,
+---
+>                                 "line": 4269,
+18190c17950
+<                                 "line": 4265,
+---
+>                                 "line": 4269,
+18194c17954
+<                                 "line": 4265,
+---
+>                                 "line": 4269,
+18205c17965
+<                                 "line": 4265,
+---
+>                                 "line": 4269,
+18209c17969
+<                                 "line": 4265,
+---
+>                                 "line": 4269,
+18220c17980
+<                                 "line": 4265,
+---
+>                                 "line": 4269,
+18224c17984
+<                                 "line": 4265,
+---
+>                                 "line": 4269,
+18235c17995
+<                                 "line": 4265,
+---
+>                                 "line": 4269,
+18239c17999
+<                                 "line": 4265,
+---
+>                                 "line": 4269,
+18250c18010
+<                                 "line": 4265,
+---
+>                                 "line": 4269,
+18254c18014
+<                                 "line": 4265,
+---
+>                                 "line": 4269,
+18275c18035
+<                                 "line": 4272,
+---
+>                                 "line": 4276,
+18279c18039
+<                                 "line": 4272,
+---
+>                                 "line": 4276,
+18290c18050
+<                                 "line": 4272,
+---
+>                                 "line": 4276,
+18294c18054
+<                                 "line": 4272,
+---
+>                                 "line": 4276,
+18315c18075
+<                                 "line": 4279,
+---
+>                                 "line": 4283,
+18319c18079
+<                                 "line": 4279,
+---
+>                                 "line": 4283,
+18358c18118
+<                                 "line": 4337,
+---
+>                                 "line": 4341,
+18362c18122
+<                                 "line": 4337,
+---
+>                                 "line": 4341,
+18373c18133
+<                                 "line": 4337,
+---
+>                                 "line": 4341,
+18377c18137
+<                                 "line": 4337,
+---
+>                                 "line": 4341,
+18388c18148
+<                                 "line": 4337,
+---
+>                                 "line": 4341,
+18392c18152
+<                                 "line": 4337,
+---
+>                                 "line": 4341,
+18413c18173
+<                                 "line": 4353,
+---
+>                                 "line": 4357,
+18417c18177
+<                                 "line": 4353,
+---
+>                                 "line": 4357,
+18428c18188
+<                                 "line": 4353,
+---
+>                                 "line": 4357,
+18432c18192
+<                                 "line": 4353,
+---
+>                                 "line": 4357,
+18443c18203
+<                                 "line": 4353,
+---
+>                                 "line": 4357,
+18447c18207
+<                                 "line": 4353,
+---
+>                                 "line": 4357,
+18468c18228
+<                                 "line": 4360,
+---
+>                                 "line": 4364,
+18472c18232
+<                                 "line": 4360,
+---
+>                                 "line": 4364,
+18493c18253
+<                                 "line": 4367,
+---
+>                                 "line": 4371,
+18497c18257
+<                                 "line": 4367,
+---
+>                                 "line": 4371,
+18518c18278
+<                                 "line": 4374,
+---
+>                                 "line": 4378,
+18522c18282
+<                                 "line": 4374,
+---
+>                                 "line": 4378,
+18543c18303
+<                                 "line": 4381,
+---
+>                                 "line": 4385,
+18547c18307
+<                                 "line": 4381,
+---
+>                                 "line": 4385,
+18568c18328
+<                                 "line": 4388,
+---
+>                                 "line": 4392,
+18572c18332
+<                                 "line": 4388,
+---
+>                                 "line": 4392,
+18593c18353
+<                                 "line": 4395,
+---
+>                                 "line": 4399,
+18597c18357
+<                                 "line": 4395,
+---
+>                                 "line": 4399,
+18618c18378
+<                                 "line": 4402,
+---
+>                                 "line": 4406,
+18622c18382
+<                                 "line": 4402,
+---
+>                                 "line": 4406,
+18643c18403
+<                                 "line": 4409,
+---
+>                                 "line": 4413,
+18647c18407
+<                                 "line": 4409,
+---
+>                                 "line": 4413,
+18668c18428
+<                                 "line": 4416,
+---
+>                                 "line": 4420,
+18672c18432
+<                                 "line": 4416,
+---
+>                                 "line": 4420,
+18693c18453
+<                                 "line": 4423,
+---
+>                                 "line": 4427,
+18697c18457
+<                                 "line": 4423,
+---
+>                                 "line": 4427,
+18718c18478
+<                                 "line": 4430,
+---
+>                                 "line": 4434,
+18722c18482
+<                                 "line": 4430,
+---
+>                                 "line": 4434,
+18743c18503
+<                                 "line": 4489,
+---
+>                                 "line": 4493,
+18747c18507
+<                                 "line": 4489,
+---
+>                                 "line": 4493,
+18758c18518
+<                                 "line": 4489,
+---
+>                                 "line": 4493,
+18762c18522
+<                                 "line": 4489,
+---
+>                                 "line": 4493,
+18783c18543
+<                                 "line": 4534,
+---
+>                                 "line": 4538,
+18787c18547
+<                                 "line": 4534,
+---
+>                                 "line": 4538,
+18798c18558
+<                                 "line": 4534,
+---
+>                                 "line": 4538,
+18802c18562
+<                                 "line": 4534,
+---
+>                                 "line": 4538,
+18823c18583
+<                                 "line": 4548,
+---
+>                                 "line": 4552,
+18827c18587
+<                                 "line": 4548,
+---
+>                                 "line": 4552,
+18848c18608
+<                                 "line": 4555,
+---
+>                                 "line": 4559,
+18852c18612
+<                                 "line": 4555,
+---
+>                                 "line": 4559,
+18873c18633
+<                                 "line": 4562,
+---
+>                                 "line": 4566,
+18877c18637
+<                                 "line": 4562,
+---
+>                                 "line": 4566,
+18888c18648
+<                                 "line": 4562,
+---
+>                                 "line": 4566,
+18892c18652
+<                                 "line": 4562,
+---
+>                                 "line": 4566,
+18913c18673
+<                                 "line": 4595,
+---
+>                                 "line": 4599,
+18917c18677
+<                                 "line": 4595,
+---
+>                                 "line": 4599,
+18928c18688
+<                                 "line": 4595,
+---
+>                                 "line": 4599,
+18932c18692
+<                                 "line": 4595,
+---
+>                                 "line": 4599,
+18943c18703
+<                                 "line": 4595,
+---
+>                                 "line": 4599,
+18947c18707
+<                                 "line": 4595,
+---
+>                                 "line": 4599,
+18968c18728
+<                                 "line": 4602,
+---
+>                                 "line": 4606,
+18972c18732
+<                                 "line": 4602,
+---
+>                                 "line": 4606,
+18993c18753
+<                                 "line": 4645,
+---
+>                                 "line": 4649,
+18997c18757
+<                                 "line": 4645,
+---
+>                                 "line": 4649,
+19018c18778
+<                                 "line": 4652,
+---
+>                                 "line": 4656,
+19022c18782
+<                                 "line": 4652,
+---
+>                                 "line": 4656,
+19043c18803
+<                                 "line": 4694,
+---
+>                                 "line": 4698,
+19047c18807
+<                                 "line": 4694,
+---
+>                                 "line": 4698,
+19058c18818
+<                                 "line": 4694,
+---
+>                                 "line": 4698,
+19062c18822
+<                                 "line": 4694,
+---
+>                                 "line": 4698,
+19073c18833
+<                                 "line": 4694,
+---
+>                                 "line": 4698,
+19077c18837
+<                                 "line": 4694,
+---
+>                                 "line": 4698,
+19088c18848
+<                                 "line": 4694,
+---
+>                                 "line": 4698,
+19092c18852
+<                                 "line": 4694,
+---
+>                                 "line": 4698,
+19113c18873
+<                                 "line": 4714,
+---
+>                                 "line": 4718,
+19117c18877
+<                                 "line": 4714,
+---
+>                                 "line": 4718,
+19128c18888
+<                                 "line": 4714,
+---
+>                                 "line": 4718,
+19132c18892
+<                                 "line": 4714,
+---
+>                                 "line": 4718,
+19153c18913
+<                                 "line": 4721,
+---
+>                                 "line": 4725,
+19157c18917
+<                                 "line": 4721,
+---
+>                                 "line": 4725,
+19178c18938
+<                                 "line": 4728,
+---
+>                                 "line": 4732,
+19182c18942
+<                                 "line": 4728,
+---
+>                                 "line": 4732,
+19203c18963
+<                                 "line": 4735,
+---
+>                                 "line": 4739,
+19207c18967
+<                                 "line": 4735,
+---
+>                                 "line": 4739,
+19228c18988
+<                                 "line": 4755,
+---
+>                                 "line": 4759,
+19232c18992
+<                                 "line": 4755,
+---
+>                                 "line": 4759,
+19243c19003
+<                                 "line": 4755,
+---
+>                                 "line": 4759,
+19247c19007
+<                                 "line": 4755,
+---
+>                                 "line": 4759,
+19258c19018
+<                                 "line": 4755,
+---
+>                                 "line": 4759,
+19262c19022
+<                                 "line": 4755,
+---
+>                                 "line": 4759,
+19283c19043
+<                                 "line": 4771,
+---
+>                                 "line": 4775,
+19287c19047
+<                                 "line": 4771,
+---
+>                                 "line": 4775,
+19298c19058
+<                                 "line": 4771,
+---
+>                                 "line": 4775,
+19302c19062
+<                                 "line": 4771,
+---
+>                                 "line": 4775,
+19313c19073
+<                                 "line": 4771,
+---
+>                                 "line": 4775,
+19317c19077
+<                                 "line": 4771,
+---
+>                                 "line": 4775,
+19338c19098
+<                                 "line": 4778,
+---
+>                                 "line": 4782,
+19342c19102
+<                                 "line": 4778,
+---
+>                                 "line": 4782,
+19363c19123
+<                                 "line": 4785,
+---
+>                                 "line": 4789,
+19367c19127
+<                                 "line": 4785,
+---
+>                                 "line": 4789,
+19388c19148
+<                                 "line": 4792,
+---
+>                                 "line": 4796,
+19392c19152
+<                                 "line": 4792,
+---
+>                                 "line": 4796,
+19403c19163
+<                                 "line": 4792,
+---
+>                                 "line": 4796,
+19407c19167
+<                                 "line": 4792,
+---
+>                                 "line": 4796,
+19418c19178
+<                                 "line": 4792,
+---
+>                                 "line": 4796,
+19422c19182
+<                                 "line": 4792,
+---
+>                                 "line": 4796,
+19443c19203
+<                                 "line": 4804,
+---
+>                                 "line": 4808,
+19447c19207
+<                                 "line": 4804,
+---
+>                                 "line": 4808,
+19458c19218
+<                                 "line": 4804,
+---
+>                                 "line": 4808,
+19462c19222
+<                                 "line": 4804,
+---
+>                                 "line": 4808,
+19483c19243
+<                                 "line": 4814,
+---
+>                                 "line": 4818,
+19487c19247
+<                                 "line": 4814,
+---
+>                                 "line": 4818,
+19498c19258
+<                                 "line": 4814,
+---
+>                                 "line": 4818,
+19502c19262
+<                                 "line": 4814,
+---
+>                                 "line": 4818,
+19523c19283
+<                                 "line": 4821,
+---
+>                                 "line": 4825,
+19527c19287
+<                                 "line": 4821,
+---
+>                                 "line": 4825,
+19538c19298
+<                                 "line": 4821,
+---
+>                                 "line": 4825,
+19542c19302
+<                                 "line": 4821,
+---
+>                                 "line": 4825,
+19563c19323
+<                                 "line": 4837,
+---
+>                                 "line": 4841,
+19567c19327
+<                                 "line": 4837,
+---
+>                                 "line": 4841,
+19578c19338
+<                                 "line": 4837,
+---
+>                                 "line": 4841,
+19582c19342
+<                                 "line": 4837,
+---
+>                                 "line": 4841,
+19593c19353
+<                                 "line": 4837,
+---
+>                                 "line": 4841,
+19597c19357
+<                                 "line": 4837,
+---
+>                                 "line": 4841,
+19618c19378
+<                                 "line": 4853,
+---
+>                                 "line": 4857,
+19622c19382
+<                                 "line": 4853,
+---
+>                                 "line": 4857,
+19633c19393
+<                                 "line": 4853,
+---
+>                                 "line": 4857,
+19637c19397
+<                                 "line": 4853,
+---
+>                                 "line": 4857,
+19648c19408
+<                                 "line": 4853,
+---
+>                                 "line": 4857,
+19652c19412
+<                                 "line": 4853,
+---
+>                                 "line": 4857,
+19673c19433
+<                                 "line": 4860,
+---
+>                                 "line": 4864,
+19677c19437
+<                                 "line": 4860,
+---
+>                                 "line": 4864,
+19698c19458
+<                                 "line": 4867,
+---
+>                                 "line": 4871,
+19702c19462
+<                                 "line": 4867,
+---
+>                                 "line": 4871,
+19723c19483
+<                                 "line": 4874,
+---
+>                                 "line": 4878,
+19727c19487
+<                                 "line": 4874,
+---
+>                                 "line": 4878,
+19838c19598
+<                                 "line": 4896,
+---
+>                                 "line": 4900,
+19842c19602
+<                                 "line": 4896,
+---
+>                                 "line": 4900,
+19853c19613
+<                                 "line": 4896,
+---
+>                                 "line": 4900,
+19857c19617
+<                                 "line": 4896,
+---
+>                                 "line": 4900,
+19868c19628
+<                                 "line": 4896,
+---
+>                                 "line": 4900,
+19872c19632
+<                                 "line": 4896,
+---
+>                                 "line": 4900,
+19883c19643
+<                                 "line": 4896,
+---
+>                                 "line": 4900,
+19887c19647
+<                                 "line": 4896,
+---
+>                                 "line": 4900,
+19908c19668
+<                                 "line": 4909,
+---
+>                                 "line": 4913,
+19912c19672
+<                                 "line": 4909,
+---
+>                                 "line": 4913,
+19923c19683
+<                                 "line": 4909,
+---
+>                                 "line": 4913,
+19927c19687
+<                                 "line": 4909,
+---
+>                                 "line": 4913,
+19948c19708
+<                                 "line": 4916,
+---
+>                                 "line": 4920,
+19952c19712
+<                                 "line": 4916,
+---
+>                                 "line": 4920,
+19963c19723
+<                                 "line": 4916,
+---
+>                                 "line": 4920,
+19967c19727
+<                                 "line": 4916,
+---
+>                                 "line": 4920,
+19988c19748
+<                                 "line": 4932,
+---
+>                                 "line": 4936,
+19992c19752
+<                                 "line": 4932,
+---
+>                                 "line": 4936,
+20003c19763
+<                                 "line": 4932,
+---
+>                                 "line": 4936,
+20007c19767
+<                                 "line": 4932,
+---
+>                                 "line": 4936,
+20018c19778
+<                                 "line": 4932,
+---
+>                                 "line": 4936,
+20022c19782
+<                                 "line": 4932,
+---
+>                                 "line": 4936,
+20043c19803
+<                                 "line": 4948,
+---
+>                                 "line": 4952,
+20047c19807
+<                                 "line": 4948,
+---
+>                                 "line": 4952,
+20058c19818
+<                                 "line": 4948,
+---
+>                                 "line": 4952,
+20062c19822
+<                                 "line": 4948,
+---
+>                                 "line": 4952,
+20073c19833
+<                                 "line": 4948,
+---
+>                                 "line": 4952,
+20077c19837
+<                                 "line": 4948,
+---
+>                                 "line": 4952,
+20098c19858
+<                                 "line": 4955,
+---
+>                                 "line": 4959,
+20102c19862
+<                                 "line": 4955,
+---
+>                                 "line": 4959,
+20113c19873
+<                                 "line": 4955,
+---
+>                                 "line": 4959,
+20117c19877
+<                                 "line": 4955,
+---
+>                                 "line": 4959,
+20138c19898
+<                                 "line": 4976,
+---
+>                                 "line": 4980,
+20142c19902
+<                                 "line": 4976,
+---
+>                                 "line": 4980,
+20253c20013
+<                                 "line": 4983,
+---
+>                                 "line": 4987,
+20257c20017
+<                                 "line": 4983,
+---
+>                                 "line": 4987,
+20268c20028
+<                                 "line": 4983,
+---
+>                                 "line": 4987,
+20272c20032
+<                                 "line": 4983,
+---
+>                                 "line": 4987,
+20302c20062
+<                                 "line": 5015,
+---
+>                                 "line": 5019,
+20306c20066
+<                                 "line": 5015,
+---
+>                                 "line": 5019,
+20317c20077
+<                                 "line": 5015,
+---
+>                                 "line": 5019,
+20321c20081
+<                                 "line": 5015,
+---
+>                                 "line": 5019,
+20332c20092
+<                                 "line": 5015,
+---
+>                                 "line": 5019,
+20336c20096
+<                                 "line": 5015,
+---
+>                                 "line": 5019,
+20357c20117
+<                                 "line": 5031,
+---
+>                                 "line": 5035,
+20361c20121
+<                                 "line": 5031,
+---
+>                                 "line": 5035,
+20372c20132
+<                                 "line": 5031,
+---
+>                                 "line": 5035,
+20376c20136
+<                                 "line": 5031,
+---
+>                                 "line": 5035,
+20387c20147
+<                                 "line": 5031,
+---
+>                                 "line": 5035,
+20391c20151
+<                                 "line": 5031,
+---
+>                                 "line": 5035,
+20412c20172
+<                                 "line": 5047,
+---
+>                                 "line": 5051,
+20416c20176
+<                                 "line": 5047,
+---
+>                                 "line": 5051,
+20427c20187
+<                                 "line": 5047,
+---
+>                                 "line": 5051,
+20431c20191
+<                                 "line": 5047,
+---
+>                                 "line": 5051,
+20442c20202
+<                                 "line": 5047,
+---
+>                                 "line": 5051,
+20446c20206
+<                                 "line": 5047,
+---
+>                                 "line": 5051,
+20467c20227
+<                                 "line": 5063,
+---
+>                                 "line": 5067,
+20471c20231
+<                                 "line": 5063,
+---
+>                                 "line": 5067,
+20482c20242
+<                                 "line": 5063,
+---
+>                                 "line": 5067,
+20486c20246
+<                                 "line": 5063,
+---
+>                                 "line": 5067,
+20497c20257
+<                                 "line": 5063,
+---
+>                                 "line": 5067,
+20501c20261
+<                                 "line": 5063,
+---
+>                                 "line": 5067,
+20522c20282
+<                                 "line": 5079,
+---
+>                                 "line": 5083,
+20526c20286
+<                                 "line": 5079,
+---
+>                                 "line": 5083,
+20537c20297
+<                                 "line": 5079,
+---
+>                                 "line": 5083,
+20541c20301
+<                                 "line": 5079,
+---
+>                                 "line": 5083,
+20552c20312
+<                                 "line": 5079,
+---
+>                                 "line": 5083,
+20556c20316
+<                                 "line": 5079,
+---
+>                                 "line": 5083,
+20577c20337
+<                                 "line": 5095,
+---
+>                                 "line": 5099,
+20581c20341
+<                                 "line": 5095,
+---
+>                                 "line": 5099,
+20592c20352
+<                                 "line": 5095,
+---
+>                                 "line": 5099,
+20596c20356
+<                                 "line": 5095,
+---
+>                                 "line": 5099,
+20607c20367
+<                                 "line": 5095,
+---
+>                                 "line": 5099,
+20611c20371
+<                                 "line": 5095,
+---
+>                                 "line": 5099,
+20632c20392
+<                                 "line": 5102,
+---
+>                                 "line": 5106,
+20636c20396
+<                                 "line": 5102,
+---
+>                                 "line": 5106,
+20657c20417
+<                                 "line": 5113,
+---
+>                                 "line": 5117,
+20661c20421
+<                                 "line": 5113,
+---
+>                                 "line": 5117,
+20691c20451
+<                                 "line": 5134,
+---
+>                                 "line": 5138,
+20695c20455
+<                                 "line": 5134,
+---
+>                                 "line": 5138,
+20706c20466
+<                                 "line": 5134,
+---
+>                                 "line": 5138,
+20710c20470
+<                                 "line": 5134,
+---
+>                                 "line": 5138,
+20731c20491
+<                                 "line": 5140,
+---
+>                                 "line": 5144,
+20735c20495
+<                                 "line": 5140,
+---
+>                                 "line": 5144,
+20746c20506
+<                                 "line": 5140,
+---
+>                                 "line": 5144,
+20750c20510
+<                                 "line": 5140,
+---
+>                                 "line": 5144,
+20771c20531
+<                                 "line": 5147,
+---
+>                                 "line": 5151,
+20775c20535
+<                                 "line": 5147,
+---
+>                                 "line": 5151,
+20786c20546
+<                                 "line": 5147,
+---
+>                                 "line": 5151,
+20790c20550
+<                                 "line": 5147,
+---
+>                                 "line": 5151,
+20811c20571
+<                                 "line": 5154,
+---
+>                                 "line": 5158,
+20815c20575
+<                                 "line": 5154,
+---
+>                                 "line": 5158,
+20836c20596
+<                                 "line": 5181,
+---
+>                                 "line": 5185,
+20840c20600
+<                                 "line": 5181,
+---
+>                                 "line": 5185,
+20851c20611
+<                                 "line": 5181,
+---
+>                                 "line": 5185,
+20855c20615
+<                                 "line": 5181,
+---
+>                                 "line": 5185,
+20866c20626
+<                                 "line": 5181,
+---
+>                                 "line": 5185,
+20870c20630
+<                                 "line": 5181,
+---
+>                                 "line": 5185,
+20881c20641
+<                                 "line": 5181,
+---
+>                                 "line": 5185,
+20885c20645
+<                                 "line": 5181,
+---
+>                                 "line": 5185,
+20896c20656
+<                                 "line": 5181,
+---
+>                                 "line": 5185,
+20900c20660
+<                                 "line": 5181,
+---
+>                                 "line": 5185,
+21020c20780
+<                                 "line": 5219,
+---
+>                                 "line": 5223,
+21024c20784
+<                                 "line": 5219,
+---
+>                                 "line": 5223,
+21035c20795
+<                                 "line": 5219,
+---
+>                                 "line": 5223,
+21039c20799
+<                                 "line": 5219,
+---
+>                                 "line": 5223,
+21060c20820
+<                                 "line": 5226,
+---
+>                                 "line": 5230,
+21064c20824
+<                                 "line": 5226,
+---
+>                                 "line": 5230,
+21075c20835
+<                                 "line": 5226,
+---
+>                                 "line": 5230,
+21079c20839
+<                                 "line": 5226,
+---
+>                                 "line": 5230,
+21100c20860
+<                                 "line": 5233,
+---
+>                                 "line": 5237,
+21104c20864
+<                                 "line": 5233,
+---
+>                                 "line": 5237,
+21125c20885
+<                                 "line": 5240,
+---
+>                                 "line": 5244,
+21129c20889
+<                                 "line": 5240,
+---
+>                                 "line": 5244,
+21150c20910
+<                                 "line": 5247,
+---
+>                                 "line": 5251,
+21154c20914
+<                                 "line": 5247,
+---
+>                                 "line": 5251,
+21165c20925
+<                                 "line": 5247,
+---
+>                                 "line": 5251,
+21169c20929
+<                                 "line": 5247,
+---
+>                                 "line": 5251,
+21190c20950
+<                                 "line": 5254,
+---
+>                                 "line": 5258,
+21194c20954
+<                                 "line": 5254,
+---
+>                                 "line": 5258,
+21205c20965
+<                                 "line": 5254,
+---
+>                                 "line": 5258,
+21209c20969
+<                                 "line": 5254,
+---
+>                                 "line": 5258,
+21230c20990
+<                                 "line": 5261,
+---
+>                                 "line": 5265,
+21234c20994
+<                                 "line": 5261,
+---
+>                                 "line": 5265,
+21245c21005
+<                                 "line": 5261,
+---
+>                                 "line": 5265,
+21249c21009
+<                                 "line": 5261,
+---
+>                                 "line": 5265,
+21270c21030
+<                                 "line": 5267,
+---
+>                                 "line": 5271,
+21274c21034
+<                                 "line": 5267,
+---
+>                                 "line": 5271,
+21285c21045
+<                                 "line": 5267,
+---
+>                                 "line": 5271,
+21289c21049
+<                                 "line": 5267,
+---
+>                                 "line": 5271,
+21310c21070
+<                                 "line": 5289,
+---
+>                                 "line": 5293,
+21314c21074
+<                                 "line": 5289,
+---
+>                                 "line": 5293,
+21325c21085
+<                                 "line": 5289,
+---
+>                                 "line": 5293,
+21329c21089
+<                                 "line": 5289,
+---
+>                                 "line": 5293,
+21340c21100
+<                                 "line": 5289,
+---
+>                                 "line": 5293,
+21344c21104
+<                                 "line": 5289,
+---
+>                                 "line": 5293,
+21355c21115
+<                                 "line": 5289,
+---
+>                                 "line": 5293,
+21359c21119
+<                                 "line": 5289,
+---
+>                                 "line": 5293,
+21370c21130
+<                                 "line": 5289,
+---
+>                                 "line": 5293,
+21374c21134
+<                                 "line": 5289,
+---
+>                                 "line": 5293,
+21385c21145
+<                                 "line": 5289,
+---
+>                                 "line": 5293,
+21389c21149
+<                                 "line": 5289,
+---
+>                                 "line": 5293,
+21410c21170
+<                                 "line": 5303,
+---
+>                                 "line": 5307,
+21414c21174
+<                                 "line": 5303,
+---
+>                                 "line": 5307,
+21425c21185
+<                                 "line": 5303,
+---
+>                                 "line": 5307,
+21429c21189
+<                                 "line": 5303,
+---
+>                                 "line": 5307,
+21440c21200
+<                                 "line": 5303,
+---
+>                                 "line": 5307,
+21444c21204
+<                                 "line": 5303,
+---
+>                                 "line": 5307,
+21465c21225
+<                                 "line": 5369,
+---
+>                                 "line": 5373,
+21469c21229
+<                                 "line": 5369,
+---
+>                                 "line": 5373,
+21480c21240
+<                                 "line": 5369,
+---
+>                                 "line": 5373,
+21484c21244
+<                                 "line": 5369,
+---
+>                                 "line": 5373,
+21495c21255
+<                                 "line": 5369,
+---
+>                                 "line": 5373,
+21499c21259
+<                                 "line": 5369,
+---
+>                                 "line": 5373,
+21510c21270
+<                                 "line": 5369,
+---
+>                                 "line": 5373,
+21514c21274
+<                                 "line": 5369,
+---
+>                                 "line": 5373,
+21525c21285
+<                                 "line": 5369,
+---
+>                                 "line": 5373,
+21529c21289
+<                                 "line": 5369,
+---
+>                                 "line": 5373,
+21540c21300
+<                                 "line": 5369,
+---
+>                                 "line": 5373,
+21544c21304
+<                                 "line": 5369,
+---
+>                                 "line": 5373,
+21565c21325
+<                                 "line": 5419,
+---
+>                                 "line": 5423,
+21569c21329
+<                                 "line": 5419,
+---
+>                                 "line": 5423,
+21580c21340
+<                                 "line": 5419,
+---
+>                                 "line": 5423,
+21584c21344
+<                                 "line": 5419,
+---
+>                                 "line": 5423,
+21595c21355
+<                                 "line": 5419,
+---
+>                                 "line": 5423,
+21599c21359
+<                                 "line": 5419,
+---
+>                                 "line": 5423,
+21610c21370
+<                                 "line": 5419,
+---
+>                                 "line": 5423,
+21614c21374
+<                                 "line": 5419,
+---
+>                                 "line": 5423,
+21625c21385
+<                                 "line": 5419,
+---
+>                                 "line": 5423,
+21629c21389
+<                                 "line": 5419,
+---
+>                                 "line": 5423,
+21640c21400
+<                                 "line": 5419,
+---
+>                                 "line": 5423,
+21644c21404
+<                                 "line": 5419,
+---
+>                                 "line": 5423,
+21665c21425
+<                                 "line": 5495,
+---
+>                                 "line": 5499,
+21669c21429
+<                                 "line": 5495,
+---
+>                                 "line": 5499,
+21680c21440
+<                                 "line": 5495,
+---
+>                                 "line": 5499,
+21684c21444
+<                                 "line": 5495,
+---
+>                                 "line": 5499,
+21695c21455
+<                                 "line": 5495,
+---
+>                                 "line": 5499,
+21699c21459
+<                                 "line": 5495,
+---
+>                                 "line": 5499,
+21710c21470
+<                                 "line": 5495,
+---
+>                                 "line": 5499,
+21714c21474
+<                                 "line": 5495,
+---
+>                                 "line": 5499,
+21725c21485
+<                                 "line": 5495,
+---
+>                                 "line": 5499,
+21729c21489
+<                                 "line": 5495,
+---
+>                                 "line": 5499,
+21740c21500
+<                                 "line": 5495,
+---
+>                                 "line": 5499,
+21744c21504
+<                                 "line": 5495,
+---
+>                                 "line": 5499,
+21755c21515
+<                                 "line": 5495,
+---
+>                                 "line": 5499,
+21759c21519
+<                                 "line": 5495,
+---
+>                                 "line": 5499,
+21770c21530
+<                                 "line": 5495,
+---
+>                                 "line": 5499,
+21774c21534
+<                                 "line": 5495,
+---
+>                                 "line": 5499,
+21785c21545
+<                                 "line": 5495,
+---
+>                                 "line": 5499,
+21789c21549
+<                                 "line": 5495,
+---
+>                                 "line": 5499,
+21800c21560
+<                                 "line": 5495,
+---
+>                                 "line": 5499,
+21804c21564
+<                                 "line": 5495,
+---
+>                                 "line": 5499,
+21825c21585
+<                                 "line": 5587,
+---
+>                                 "line": 5591,
+21829c21589
+<                                 "line": 5587,
+---
+>                                 "line": 5591,
+21840c21600
+<                                 "line": 5587,
+---
+>                                 "line": 5591,
+21844c21604
+<                                 "line": 5587,
+---
+>                                 "line": 5591,
+21855c21615
+<                                 "line": 5587,
+---
+>                                 "line": 5591,
+21859c21619
+<                                 "line": 5587,
+---
+>                                 "line": 5591,
+21870c21630
+<                                 "line": 5587,
+---
+>                                 "line": 5591,
+21874c21634
+<                                 "line": 5587,
+---
+>                                 "line": 5591,
+21885c21645
+<                                 "line": 5587,
+---
+>                                 "line": 5591,
+21889c21649
+<                                 "line": 5587,
+---
+>                                 "line": 5591,
+21900c21660
+<                                 "line": 5587,
+---
+>                                 "line": 5591,
+21904c21664
+<                                 "line": 5587,
+---
+>                                 "line": 5591,
+21915c21675
+<                                 "line": 5587,
+---
+>                                 "line": 5591,
+21919c21679
+<                                 "line": 5587,
+---
+>                                 "line": 5591,
+21930c21690
+<                                 "line": 5587,
+---
+>                                 "line": 5591,
+21934c21694
+<                                 "line": 5587,
+---
+>                                 "line": 5591,
+21945c21705
+<                                 "line": 5587,
+---
+>                                 "line": 5591,
+21949c21709
+<                                 "line": 5587,
+---
+>                                 "line": 5591,
+21960c21720
+<                                 "line": 5587,
+---
+>                                 "line": 5591,
+21964c21724
+<                                 "line": 5587,
+---
+>                                 "line": 5591,
+21985c21745
+<                                 "line": 5614,
+---
+>                                 "line": 5618,
+21989c21749
+<                                 "line": 5614,
+---
+>                                 "line": 5618,
+22000c21760
+<                                 "line": 5614,
+---
+>                                 "line": 5618,
+22004c21764
+<                                 "line": 5614,
+---
+>                                 "line": 5618,
+22025c21785
+<                                 "line": 5626,
+---
+>                                 "line": 5630,
+22029c21789
+<                                 "line": 5626,
+---
+>                                 "line": 5630,
+22040c21800
+<                                 "line": 5626,
+---
+>                                 "line": 5630,
+22044c21804
+<                                 "line": 5626,
+---
+>                                 "line": 5630,
+22065c21825
+<                                 "line": 5650,
+---
+>                                 "line": 5654,
+22069c21829
+<                                 "line": 5650,
+---
+>                                 "line": 5654,
+22080c21840
+<                                 "line": 5650,
+---
+>                                 "line": 5654,
+22084c21844
+<                                 "line": 5650,
+---
+>                                 "line": 5654,
+22095c21855
+<                                 "line": 5650,
+---
+>                                 "line": 5654,
+22099c21859
+<                                 "line": 5650,
+---
+>                                 "line": 5654,
+22110c21870
+<                                 "line": 5650,
+---
+>                                 "line": 5654,
+22114c21874
+<                                 "line": 5650,
+---
+>                                 "line": 5654,
+22135c21895
+<                                 "line": 5659,
+---
+>                                 "line": 5663,
+22139c21899
+<                                 "line": 5659,
+---
+>                                 "line": 5663,
+22150c21910
+<                                 "line": 5659,
+---
+>                                 "line": 5663,
+22154c21914
+<                                 "line": 5659,
+---
+>                                 "line": 5663,
+22165c21925
+<                                 "line": 5659,
+---
+>                                 "line": 5663,
+22169c21929
+<                                 "line": 5659,
+---
+>                                 "line": 5663,
+22190c21950
+<                                 "line": 5743,
+---
+>                                 "line": 5747,
+22194c21954
+<                                 "line": 5743,
+---
+>                                 "line": 5747,
+22205c21965
+<                                 "line": 5743,
+---
+>                                 "line": 5747,
+22209c21969
+<                                 "line": 5743,
+---
+>                                 "line": 5747,
+22220c21980
+<                                 "line": 5743,
+---
+>                                 "line": 5747,
+22224c21984
+<                                 "line": 5743,
+---
+>                                 "line": 5747,
+22235c21995
+<                                 "line": 5743,
+---
+>                                 "line": 5747,
+22239c21999
+<                                 "line": 5743,
+---
+>                                 "line": 5747,
+22260c22020
+<                                 "line": 5754,
+---
+>                                 "line": 5758,
+22264c22024
+<                                 "line": 5754,
+---
+>                                 "line": 5758,
+22285c22045
+<                                 "line": 5770,
+---
+>                                 "line": 5774,
+22289c22049
+<                                 "line": 5770,
+---
+>                                 "line": 5774,
+22300c22060
+<                                 "line": 5770,
+---
+>                                 "line": 5774,
+22304c22064
+<                                 "line": 5770,
+---
+>                                 "line": 5774,
+22325c22085
+<                                 "line": 5777,
+---
+>                                 "line": 5781,
+22329c22089
+<                                 "line": 5777,
+---
+>                                 "line": 5781,
+22350c22110
+<                                 "line": 5788,
+---
+>                                 "line": 5792,
+22354c22114
+<                                 "line": 5788,
+---
+>                                 "line": 5792,
+22375c22135
+<                                 "line": 5797,
+---
+>                                 "line": 5801,
+22379c22139
+<                                 "line": 5797,
+---
+>                                 "line": 5801,
+22454c22214
+<                                 "line": 5850,
+---
+>                                 "line": 5854,
+22458c22218
+<                                 "line": 5850,
+---
+>                                 "line": 5854,
+22578c22338
+<                                 "line": 5916,
+---
+>                                 "line": 5920,
+22582c22342
+<                                 "line": 5916,
+---
+>                                 "line": 5920,
+22621c22381
+<                                 "line": 5925,
+---
+>                                 "line": 5929,
+22625c22385
+<                                 "line": 5925,
+---
+>                                 "line": 5929,
+22636c22396
+<                                 "line": 5925,
+---
+>                                 "line": 5929,
+22640c22400
+<                                 "line": 5925,
+---
+>                                 "line": 5929,
+22661c22421
+<                                 "line": 5926,
+---
+>                                 "line": 5930,
+22665c22425
+<                                 "line": 5926,
+---
+>                                 "line": 5930,
+22731c22491
+<                                 "line": 5948,
+---
+>                                 "line": 5952,
+22735c22495
+<                                 "line": 5948,
+---
+>                                 "line": 5952,
+22746c22506
+<                                 "line": 5948,
+---
+>                                 "line": 5952,
+22750c22510
+<                                 "line": 5948,
+---
+>                                 "line": 5952,
+22771c22531
+<                                 "line": 5961,
+---
+>                                 "line": 5965,
+22775c22535
+<                                 "line": 5961,
+---
+>                                 "line": 5965,
+22796c22556
+<                                 "line": 5968,
+---
+>                                 "line": 5972,
+22800c22560
+<                                 "line": 5968,
+---
+>                                 "line": 5972,
+22821c22581
+<                                 "line": 5975,
+---
+>                                 "line": 5979,
+22825c22585
+<                                 "line": 5975,
+---
+>                                 "line": 5979,
+22846c22606
+<                                 "line": 5982,
+---
+>                                 "line": 5986,
+22850c22610
+<                                 "line": 5982,
+---
+>                                 "line": 5986,
+22871c22631
+<                                 "line": 5989,
+---
+>                                 "line": 5993,
+22875c22635
+<                                 "line": 5989,
+---
+>                                 "line": 5993,
+22896c22656
+<                                 "line": 5996,
+---
+>                                 "line": 6000,
+22900c22660
+<                                 "line": 5996,
+---
+>                                 "line": 6000,
+22921c22681
+<                                 "line": 6003,
+---
+>                                 "line": 6007,
+22925c22685
+<                                 "line": 6003,
+---
+>                                 "line": 6007,
+22936c22696
+<                                 "line": 6003,
+---
+>                                 "line": 6007,
+22940c22700
+<                                 "line": 6003,
+---
+>                                 "line": 6007,
+22970c22730
+<                                 "line": 6038,
+---
+>                                 "line": 6042,
+22974c22734
+<                                 "line": 6038,
+---
+>                                 "line": 6042,
+22985c22745
+<                                 "line": 6038,
+---
+>                                 "line": 6042,
+22989c22749
+<                                 "line": 6038,
+---
+>                                 "line": 6042,
+23010c22770
+<                                 "line": 6059,
+---
+>                                 "line": 6063,
+23014c22774
+<                                 "line": 6059,
+---
+>                                 "line": 6063,
+23025c22785
+<                                 "line": 6059,
+---
+>                                 "line": 6063,
+23029c22789
+<                                 "line": 6059,
+---
+>                                 "line": 6063,
+23140c22900
+<                                 "line": 6071,
+---
+>                                 "line": 6075,
+23144c22904
+<                                 "line": 6071,
+---
+>                                 "line": 6075,
+23155c22915
+<                                 "line": 6071,
+---
+>                                 "line": 6075,
+23159c22919
+<                                 "line": 6071,
+---
+>                                 "line": 6075,
+23180c22940
+<                                 "line": 6078,
+---
+>                                 "line": 6082,
+23184c22944
+<                                 "line": 6078,
+---
+>                                 "line": 6082,
+23195c22955
+<                                 "line": 6078,
+---
+>                                 "line": 6082,
+23199c22959
+<                                 "line": 6078,
+---
+>                                 "line": 6082,
+23220c22980
+<                                 "line": 6085,
+---
+>                                 "line": 6089,
+23224c22984
+<                                 "line": 6085,
+---
+>                                 "line": 6089,
+23235c22995
+<                                 "line": 6085,
+---
+>                                 "line": 6089,
+23239c22999
+<                                 "line": 6085,
+---
+>                                 "line": 6089,
+23260c23020
+<                                 "line": 6092,
+---
+>                                 "line": 6096,
+23264c23024
+<                                 "line": 6092,
+---
+>                                 "line": 6096,
+23275c23035
+<                                 "line": 6092,
+---
+>                                 "line": 6096,
+23279c23039
+<                                 "line": 6092,
+---
+>                                 "line": 6096,
+23300c23060
+<                                 "line": 6108,
+---
+>                                 "line": 6112,
+23304c23064
+<                                 "line": 6108,
+---
+>                                 "line": 6112,
+23315c23075
+<                                 "line": 6108,
+---
+>                                 "line": 6112,
+23319c23079
+<                                 "line": 6108,
+---
+>                                 "line": 6112,
+23330c23090
+<                                 "line": 6108,
+---
+>                                 "line": 6112,
+23334c23094
+<                                 "line": 6108,
+---
+>                                 "line": 6112,
+23355c23115
+<                                 "line": 6124,
+---
+>                                 "line": 6128,
+23359c23119
+<                                 "line": 6124,
+---
+>                                 "line": 6128,
+23370c23130
+<                                 "line": 6124,
+---
+>                                 "line": 6128,
+23374c23134
+<                                 "line": 6124,
+---
+>                                 "line": 6128,
+23385c23145
+<                                 "line": 6124,
+---
+>                                 "line": 6128,
+23389c23149
+<                                 "line": 6124,
+---
+>                                 "line": 6128,
+23410c23170
+<                                 "line": 6140,
+---
+>                                 "line": 6144,
+23414c23174
+<                                 "line": 6140,
+---
+>                                 "line": 6144,
+23425c23185
+<                                 "line": 6140,
+---
+>                                 "line": 6144,
+23429c23189
+<                                 "line": 6140,
+---
+>                                 "line": 6144,
+23440c23200
+<                                 "line": 6140,
+---
+>                                 "line": 6144,
+23444c23204
+<                                 "line": 6140,
+---
+>                                 "line": 6144,
+23455c23215
+<                                 "line": 6140,
+---
+>                                 "line": 6144,
+23459c23219
+<                                 "line": 6140,
+---
+>                                 "line": 6144,
+23470c23230
+<                                 "line": 6140,
+---
+>                                 "line": 6144,
+23474c23234
+<                                 "line": 6140,
+---
+>                                 "line": 6144,
+23495c23255
+<                                 "line": 6156,
+---
+>                                 "line": 6160,
+23499c23259
+<                                 "line": 6156,
+---
+>                                 "line": 6160,
+23510c23270
+<                                 "line": 6156,
+---
+>                                 "line": 6160,
+23514c23274
+<                                 "line": 6156,
+---
+>                                 "line": 6160,
+23525c23285
+<                                 "line": 6156,
+---
+>                                 "line": 6160,
+23529c23289
+<                                 "line": 6156,
+---
+>                                 "line": 6160,
+23540c23300
+<                                 "line": 6156,
+---
+>                                 "line": 6160,
+23544c23304
+<                                 "line": 6156,
+---
+>                                 "line": 6160,
+23555c23315
+<                                 "line": 6156,
+---
+>                                 "line": 6160,
+23559c23319
+<                                 "line": 6156,
+---
+>                                 "line": 6160,
+23580c23340
+<                                 "line": 6172,
+---
+>                                 "line": 6176,
+23584c23344
+<                                 "line": 6172,
+---
+>                                 "line": 6176,
+23595c23355
+<                                 "line": 6172,
+---
+>                                 "line": 6176,
+23599c23359
+<                                 "line": 6172,
+---
+>                                 "line": 6176,
+23610c23370
+<                                 "line": 6172,
+---
+>                                 "line": 6176,
+23614c23374
+<                                 "line": 6172,
+---
+>                                 "line": 6176,
+23635c23395
+<                                 "line": 6188,
+---
+>                                 "line": 6192,
+23639c23399
+<                                 "line": 6188,
+---
+>                                 "line": 6192,
+23650c23410
+<                                 "line": 6188,
+---
+>                                 "line": 6192,
+23654c23414
+<                                 "line": 6188,
+---
+>                                 "line": 6192,
+23665c23425
+<                                 "line": 6188,
+---
+>                                 "line": 6192,
+23669c23429
+<                                 "line": 6188,
+---
+>                                 "line": 6192,
+23690c23450
+<                                 "line": 6204,
+---
+>                                 "line": 6208,
+23694c23454
+<                                 "line": 6204,
+---
+>                                 "line": 6208,
+23705c23465
+<                                 "line": 6204,
+---
+>                                 "line": 6208,
+23709c23469
+<                                 "line": 6204,
+---
+>                                 "line": 6208,
+23720c23480
+<                                 "line": 6204,
+---
+>                                 "line": 6208,
+23724c23484
+<                                 "line": 6204,
+---
+>                                 "line": 6208,
+23745c23505
+<                                 "line": 6220,
+---
+>                                 "line": 6224,
+23749c23509
+<                                 "line": 6220,
+---
+>                                 "line": 6224,
+23760c23520
+<                                 "line": 6220,
+---
+>                                 "line": 6224,
+23764c23524
+<                                 "line": 6220,
+---
+>                                 "line": 6224,
+23775c23535
+<                                 "line": 6220,
+---
+>                                 "line": 6224,
+23779c23539
+<                                 "line": 6220,
+---
+>                                 "line": 6224,
+23800c23560
+<                                 "line": 6227,
+---
+>                                 "line": 6231,
+23804c23564
+<                                 "line": 6227,
+---
+>                                 "line": 6231,
+23825c23585
+<                                 "line": 6234,
+---
+>                                 "line": 6238,
+23829c23589
+<                                 "line": 6234,
+---
+>                                 "line": 6238,
+23850c23610
+<                                 "line": 6241,
+---
+>                                 "line": 6245,
+23854c23614
+<                                 "line": 6241,
+---
+>                                 "line": 6245,
+23875c23635
+<                                 "line": 6248,
+---
+>                                 "line": 6252,
+23879c23639
+<                                 "line": 6248,
+---
+>                                 "line": 6252,
+23900c23660
+<                                 "line": 6255,
+---
+>                                 "line": 6259,
+23904c23664
+<                                 "line": 6255,
+---
+>                                 "line": 6259,
+23925c23685
+<                                 "line": 6262,
+---
+>                                 "line": 6266,
+23929c23689
+<                                 "line": 6262,
+---
+>                                 "line": 6266,
+23950c23710
+<                                 "line": 6269,
+---
+>                                 "line": 6273,
+23954c23714
+<                                 "line": 6269,
+---
+>                                 "line": 6273,
+23975c23735
+<                                 "line": 6276,
+---
+>                                 "line": 6280,
+23979c23739
+<                                 "line": 6276,
+---
+>                                 "line": 6280,
+24000c23760
+<                                 "line": 6283,
+---
+>                                 "line": 6287,
+24004c23764
+<                                 "line": 6283,
+---
+>                                 "line": 6287,
+24025c23785
+<                                 "line": 6290,
+---
+>                                 "line": 6294,
+24029c23789
+<                                 "line": 6290,
+---
+>                                 "line": 6294,
+24050c23810
+<                                 "line": 6297,
+---
+>                                 "line": 6301,
+24054c23814
+<                                 "line": 6297,
+---
+>                                 "line": 6301,
+24065c23825
+<                                 "line": 6297,
+---
+>                                 "line": 6301,
+24069c23829
+<                                 "line": 6297,
+---
+>                                 "line": 6301,
+24090c23850
+<                                 "line": 6321,
+---
+>                                 "line": 6325,
+24094c23854
+<                                 "line": 6321,
+---
+>                                 "line": 6325,
+24105c23865
+<                                 "line": 6321,
+---
+>                                 "line": 6325,
+24109c23869
+<                                 "line": 6321,
+---
+>                                 "line": 6325,
+24130c23890
+<                                 "line": 6327,
+---
+>                                 "line": 6331,
+24134c23894
+<                                 "line": 6327,
+---
+>                                 "line": 6331,
+24145c23905
+<                                 "line": 6327,
+---
+>                                 "line": 6331,
+24149c23909
+<                                 "line": 6327,
+---
+>                                 "line": 6331,
+24170c23930
+<                                 "line": 6334,
+---
+>                                 "line": 6338,
+24174c23934
+<                                 "line": 6334,
+---
+>                                 "line": 6338,
+24185c23945
+<                                 "line": 6334,
+---
+>                                 "line": 6338,
+24189c23949
+<                                 "line": 6334,
+---
+>                                 "line": 6338,
+24210c23970
+<                                 "line": 6350,
+---
+>                                 "line": 6354,
+24214c23974
+<                                 "line": 6350,
+---
+>                                 "line": 6354,
+24225c23985
+<                                 "line": 6350,
+---
+>                                 "line": 6354,
+24229c23989
+<                                 "line": 6350,
+---
+>                                 "line": 6354,
+24250c24010
+<                                 "line": 6357,
+---
+>                                 "line": 6361,
+24254c24014
+<                                 "line": 6357,
+---
+>                                 "line": 6361,
+24275c24035
+<                                 "line": 6364,
+---
+>                                 "line": 6368,
+24279c24039
+<                                 "line": 6364,
+---
+>                                 "line": 6368,
+24290c24050
+<                                 "line": 6364,
+---
+>                                 "line": 6368,
+24294c24054
+<                                 "line": 6364,
+---
+>                                 "line": 6368,
+24315c24075
+<                                 "line": 6371,
+---
+>                                 "line": 6375,
+24319c24079
+<                                 "line": 6371,
+---
+>                                 "line": 6375,
+24330c24090
+<                                 "line": 6371,
+---
+>                                 "line": 6375,
+24334c24094
+<                                 "line": 6371,
+---
+>                                 "line": 6375,
+24355c24115
+<                                 "line": 6378,
+---
+>                                 "line": 6382,
+24359c24119
+<                                 "line": 6378,
+---
+>                                 "line": 6382,
+24380c24140
+<                                 "line": 6385,
+---
+>                                 "line": 6389,
+24384c24144
+<                                 "line": 6385,
+---
+>                                 "line": 6389,
+24405c24165
+<                                 "line": 6392,
+---
+>                                 "line": 6396,
+24409c24169
+<                                 "line": 6392,
+---
+>                                 "line": 6396,
+24420c24180
+<                                 "line": 6392,
+---
+>                                 "line": 6396,
+24424c24184
+<                                 "line": 6392,
+---
+>                                 "line": 6396,
+24445c24205
+<                                 "line": 6399,
+---
+>                                 "line": 6403,
+24449c24209
+<                                 "line": 6399,
+---
+>                                 "line": 6403,
+24460c24220
+<                                 "line": 6399,
+---
+>                                 "line": 6403,
+24464c24224
+<                                 "line": 6399,
+---
+>                                 "line": 6403,
+24485c24245
+<                                 "line": 6406,
+---
+>                                 "line": 6410,
+24489c24249
+<                                 "line": 6406,
+---
+>                                 "line": 6410,
+24500c24260
+<                                 "line": 6406,
+---
+>                                 "line": 6410,
+24504c24264
+<                                 "line": 6406,
+---
+>                                 "line": 6410,
+24525c24285
+<                                 "line": 6413,
+---
+>                                 "line": 6417,
+24529c24289
+<                                 "line": 6413,
+---
+>                                 "line": 6417,
+24540c24300
+<                                 "line": 6413,
+---
+>                                 "line": 6417,
+24544c24304
+<                                 "line": 6413,
+---
+>                                 "line": 6417,
+24565c24325
+<                                 "line": 6420,
+---
+>                                 "line": 6424,
+24569c24329
+<                                 "line": 6420,
+---
+>                                 "line": 6424,
+24590c24350
+<                                 "line": 6427,
+---
+>                                 "line": 6431,
+24594c24354
+<                                 "line": 6427,
+---
+>                                 "line": 6431,
+24615c24375
+<                                 "line": 6443,
+---
+>                                 "line": 6447,
+24619c24379
+<                                 "line": 6443,
+---
+>                                 "line": 6447,
+24630c24390
+<                                 "line": 6443,
+---
+>                                 "line": 6447,
+24634c24394
+<                                 "line": 6443,
+---
+>                                 "line": 6447,
+24655c24415
+<                                 "line": 6454,
+---
+>                                 "line": 6458,
+24659c24419
+<                                 "line": 6454,
+---
+>                                 "line": 6458,
+24680c24440
+<                                 "line": 6474,
+---
+>                                 "line": 6478,
+24684c24444
+<                                 "line": 6474,
+---
+>                                 "line": 6478,
+24695c24455
+<                                 "line": 6474,
+---
+>                                 "line": 6478,
+24699c24459
+<                                 "line": 6474,
+---
+>                                 "line": 6478,
+24710c24470
+<                                 "line": 6474,
+---
+>                                 "line": 6478,
+24714c24474
+<                                 "line": 6474,
+---
+>                                 "line": 6478,
+24735c24495
+<                                 "line": 6490,
+---
+>                                 "line": 6494,
+24739c24499
+<                                 "line": 6490,
+---
+>                                 "line": 6494,
+24750c24510
+<                                 "line": 6490,
+---
+>                                 "line": 6494,
+24754c24514
+<                                 "line": 6490,
+---
+>                                 "line": 6494,
+24765c24525
+<                                 "line": 6490,
+---
+>                                 "line": 6494,
+24769c24529
+<                                 "line": 6490,
+---
+>                                 "line": 6494,
+24790c24550
+<                                 "line": 6497,
+---
+>                                 "line": 6501,
+24794c24554
+<                                 "line": 6497,
+---
+>                                 "line": 6501,
+24805c24565
+<                                 "line": 6497,
+---
+>                                 "line": 6501,
+24809c24569
+<                                 "line": 6497,
+---
+>                                 "line": 6501,
+24820c24580
+<                                 "line": 6497,
+---
+>                                 "line": 6501,
+24824c24584
+<                                 "line": 6497,
+---
+>                                 "line": 6501,
+24845c24605
+<                                 "line": 6504,
+---
+>                                 "line": 6508,
+24849c24609
+<                                 "line": 6504,
+---
+>                                 "line": 6508,
+24860c24620
+<                                 "line": 6504,
+---
+>                                 "line": 6508,
+24864c24624
+<                                 "line": 6504,
+---
+>                                 "line": 6508,
+24875c24635
+<                                 "line": 6504,
+---
+>                                 "line": 6508,
+24879c24639
+<                                 "line": 6504,
+---
+>                                 "line": 6508,
+24890c24650
+<                                 "line": 6504,
+---
+>                                 "line": 6508,
+24894c24654
+<                                 "line": 6504,
+---
+>                                 "line": 6508,
+24915c24675
+<                                 "line": 6505,
+---
+>                                 "line": 6509,
+24919c24679
+<                                 "line": 6505,
+---
+>                                 "line": 6509,
+24930c24690
+<                                 "line": 6505,
+---
+>                                 "line": 6509,
+24934c24694
+<                                 "line": 6505,
+---
+>                                 "line": 6509,
+24955c24715
+<                                 "line": 6527,
+---
+>                                 "line": 6531,
+24959c24719
+<                                 "line": 6527,
+---
+>                                 "line": 6531,
+24970c24730
+<                                 "line": 6527,
+---
+>                                 "line": 6531,
+24974c24734
+<                                 "line": 6527,
+---
+>                                 "line": 6531,
+24985c24745
+<                                 "line": 6527,
+---
+>                                 "line": 6531,
+24989c24749
+<                                 "line": 6527,
+---
+>                                 "line": 6531,
+25000c24760
+<                                 "line": 6527,
+---
+>                                 "line": 6531,
+25004c24764
+<                                 "line": 6527,
+---
+>                                 "line": 6531,
+25015c24775
+<                                 "line": 6527,
+---
+>                                 "line": 6531,
+25019c24779
+<                                 "line": 6527,
+---
+>                                 "line": 6531,
+25040c24800
+<                                 "line": 6550,
+---
+>                                 "line": 6554,
+25044c24804
+<                                 "line": 6550,
+---
+>                                 "line": 6554,
+25055c24815
+<                                 "line": 6550,
+---
+>                                 "line": 6554,
+25059c24819
+<                                 "line": 6550,
+---
+>                                 "line": 6554,
+25070c24830
+<                                 "line": 6550,
+---
+>                                 "line": 6554,
+25074c24834
+<                                 "line": 6550,
+---
+>                                 "line": 6554,
+25085c24845
+<                                 "line": 6550,
+---
+>                                 "line": 6554,
+25089c24849
+<                                 "line": 6550,
+---
+>                                 "line": 6554,
+25100c24860
+<                                 "line": 6550,
+---
+>                                 "line": 6554,
+25104c24864
+<                                 "line": 6550,
+---
+>                                 "line": 6554,
+25125c24885
+<                                 "line": 6564,
+---
+>                                 "line": 6568,
+25129c24889
+<                                 "line": 6564,
+---
+>                                 "line": 6568,
+25140c24900
+<                                 "line": 6564,
+---
+>                                 "line": 6568,
+25144c24904
+<                                 "line": 6564,
+---
+>                                 "line": 6568,
+25155c24915
+<                                 "line": 6564,
+---
+>                                 "line": 6568,
+25159c24919
+<                                 "line": 6564,
+---
+>                                 "line": 6568,
+25180c24940
+<                                 "line": 6588,
+---
+>                                 "line": 6592,
+25184c24944
+<                                 "line": 6588,
+---
+>                                 "line": 6592,
+25195c24955
+<                                 "line": 6588,
+---
+>                                 "line": 6592,
+25199c24959
+<                                 "line": 6588,
+---
+>                                 "line": 6592,
+25210c24970
+<                                 "line": 6588,
+---
+>                                 "line": 6592,
+25214c24974
+<                                 "line": 6588,
+---
+>                                 "line": 6592,
+25235c24995
+<                                 "line": 6622,
+---
+>                                 "line": 6626,
+25239c24999
+<                                 "line": 6622,
+---
+>                                 "line": 6626,
+25250c25010
+<                                 "line": 6622,
+---
+>                                 "line": 6626,
+25254c25014
+<                                 "line": 6622,
+---
+>                                 "line": 6626,
+25275c25035
+<                                 "line": 6629,
+---
+>                                 "line": 6633,
+25279c25039
+<                                 "line": 6629,
+---
+>                                 "line": 6633,
+25290c25050
+<                                 "line": 6629,
+---
+>                                 "line": 6633,
+25294c25054
+<                                 "line": 6629,
+---
+>                                 "line": 6633,
+25315c25075
+<                                 "line": 6636,
+---
+>                                 "line": 6640,
+25319c25079
+<                                 "line": 6636,
+---
+>                                 "line": 6640,
+25340c25100
+<                                 "line": 6643,
+---
+>                                 "line": 6647,
+25344c25104
+<                                 "line": 6643,
+---
+>                                 "line": 6647,
+25365c25125
+<                                 "line": 6677,
+---
+>                                 "line": 6681,
+25369c25129
+<                                 "line": 6677,
+---
+>                                 "line": 6681,
+25380c25140
+<                                 "line": 6677,
+---
+>                                 "line": 6681,
+25384c25144
+<                                 "line": 6677,
+---
+>                                 "line": 6681,
+25395c25155
+<                                 "line": 6677,
+---
+>                                 "line": 6681,
+25399c25159
+<                                 "line": 6677,
+---
+>                                 "line": 6681,
+25410c25170
+<                                 "line": 6677,
+---
+>                                 "line": 6681,
+25414c25174
+<                                 "line": 6677,
+---
+>                                 "line": 6681,
+25425c25185
+<                                 "line": 6677,
+---
+>                                 "line": 6681,
+25429c25189
+<                                 "line": 6677,
+---
+>                                 "line": 6681,
+25540c25300
+<                                 "line": 6688,
+---
+>                                 "line": 6692,
+25544c25304
+<                                 "line": 6688,
+---
+>                                 "line": 6692,
+25555c25315
+<                                 "line": 6688,
+---
+>                                 "line": 6692,
+25559c25319
+<                                 "line": 6688,
+---
+>                                 "line": 6692,
+25580c25340
+<                                 "line": 6718,
+---
+>                                 "line": 6722,
+25584c25344
+<                                 "line": 6718,
+---
+>                                 "line": 6722,
+25595c25355
+<                                 "line": 6718,
+---
+>                                 "line": 6722,
+25599c25359
+<                                 "line": 6718,
+---
+>                                 "line": 6722,
+25610c25370
+<                                 "line": 6718,
+---
+>                                 "line": 6722,
+25614c25374
+<                                 "line": 6718,
+---
+>                                 "line": 6722,
+25635c25395
+<                                 "line": 6752,
+---
+>                                 "line": 6756,
+25639c25399
+<                                 "line": 6752,
+---
+>                                 "line": 6756,
+25650c25410
+<                                 "line": 6752,
+---
+>                                 "line": 6756,
+25654c25414
+<                                 "line": 6752,
+---
+>                                 "line": 6756,
+25665c25425
+<                                 "line": 6752,
+---
+>                                 "line": 6756,
+25669c25429
+<                                 "line": 6752,
+---
+>                                 "line": 6756,
+25780c25540
+<                                 "line": 6788,
+---
+>                                 "line": 6792,
+25784c25544
+<                                 "line": 6788,
+---
+>                                 "line": 6792,
+25795c25555
+<                                 "line": 6788,
+---
+>                                 "line": 6792,
+25799c25559
+<                                 "line": 6788,
+---
+>                                 "line": 6792,
+25810c25570
+<                                 "line": 6788,
+---
+>                                 "line": 6792,
+25814c25574
+<                                 "line": 6788,
+---
+>                                 "line": 6792,
+25825c25585
+<                                 "line": 6788,
+---
+>                                 "line": 6792,
+25829c25589
+<                                 "line": 6788,
+---
+>                                 "line": 6792,
+25840c25600
+<                                 "line": 6788,
+---
+>                                 "line": 6792,
+25844c25604
+<                                 "line": 6788,
+---
+>                                 "line": 6792,
+25955c25715
+<                                 "line": 6799,
+---
+>                                 "line": 6803,
+25959c25719
+<                                 "line": 6799,
+---
+>                                 "line": 6803,
+25970c25730
+<                                 "line": 6799,
+---
+>                                 "line": 6803,
+25974c25734
+<                                 "line": 6799,
+---
+>                                 "line": 6803,
+25995c25755
+<                                 "line": 6806,
+---
+>                                 "line": 6810,
+25999c25759
+<                                 "line": 6806,
+---
+>                                 "line": 6810,
+26010c25770
+<                                 "line": 6806,
+---
+>                                 "line": 6810,
+26014c25774
+<                                 "line": 6806,
+---
+>                                 "line": 6810,
+26035c25795
+<                                 "line": 6826,
+---
+>                                 "line": 6830,
+26039c25799
+<                                 "line": 6826,
+---
+>                                 "line": 6830,
+26050c25810
+<                                 "line": 6826,
+---
+>                                 "line": 6830,
+26054c25814
+<                                 "line": 6826,
+---
+>                                 "line": 6830,
+26165c25925
+<                                 "line": 6846,
+---
+>                                 "line": 6850,
+26169c25929
+<                                 "line": 6846,
+---
+>                                 "line": 6850,
+26180c25940
+<                                 "line": 6846,
+---
+>                                 "line": 6850,
+26184c25944
+<                                 "line": 6846,
+---
+>                                 "line": 6850,
+26205c25965
+<                                 "line": 6862,
+---
+>                                 "line": 6866,
+26209c25969
+<                                 "line": 6862,
+---
+>                                 "line": 6866,
+26220c25980
+<                                 "line": 6862,
+---
+>                                 "line": 6866,
+26224c25984
+<                                 "line": 6862,
+---
+>                                 "line": 6866,
+26245c26005
+<                                 "line": 6869,
+---
+>                                 "line": 6873,
+26249c26009
+<                                 "line": 6869,
+---
+>                                 "line": 6873,
+26270c26030
+<                                 "line": 6876,
+---
+>                                 "line": 6880,
+26274c26034
+<                                 "line": 6876,
+---
+>                                 "line": 6880,
+26285c26045
+<                                 "line": 6876,
+---
+>                                 "line": 6880,
+26289c26049
+<                                 "line": 6876,
+---
+>                                 "line": 6880,
+26300c26060
+<                                 "line": 6876,
+---
+>                                 "line": 6880,
+26304c26064
+<                                 "line": 6876,
+---
+>                                 "line": 6880,
+26325c26085
+<                                 "line": 6888,
+---
+>                                 "line": 6892,
+26329c26089
+<                                 "line": 6888,
+---
+>                                 "line": 6892,
+26340c26100
+<                                 "line": 6888,
+---
+>                                 "line": 6892,
+26344c26104
+<                                 "line": 6888,
+---
+>                                 "line": 6892,
+26365c26125
+<                                 "line": 6898,
+---
+>                                 "line": 6902,
+26369c26129
+<                                 "line": 6898,
+---
+>                                 "line": 6902,
+26380c26140
+<                                 "line": 6898,
+---
+>                                 "line": 6902,
+26384c26144
+<                                 "line": 6898,
+---
+>                                 "line": 6902,
+26405c26165
+<                                 "line": 6920,
+---
+>                                 "line": 6924,
+26409c26169
+<                                 "line": 6920,
+---
+>                                 "line": 6924,
+26420c26180
+<                                 "line": 6920,
+---
+>                                 "line": 6924,
+26424c26184
+<                                 "line": 6920,
+---
+>                                 "line": 6924,
+26435c26195
+<                                 "line": 6920,
+---
+>                                 "line": 6924,
+26439c26199
+<                                 "line": 6920,
+---
+>                                 "line": 6924,
+26460c26220
+<                                 "line": 6936,
+---
+>                                 "line": 6940,
+26464c26224
+<                                 "line": 6936,
+---
+>                                 "line": 6940,
+26475c26235
+<                                 "line": 6936,
+---
+>                                 "line": 6940,
+26479c26239
+<                                 "line": 6936,
+---
+>                                 "line": 6940,
+26490c26250
+<                                 "line": 6936,
+---
+>                                 "line": 6940,
+26494c26254
+<                                 "line": 6936,
+---
+>                                 "line": 6940,
+26515c26275
+<                                 "line": 6943,
+---
+>                                 "line": 6947,
+26519c26279
+<                                 "line": 6943,
+---
+>                                 "line": 6947,
+26530c26290
+<                                 "line": 6943,
+---
+>                                 "line": 6947,
+26534c26294
+<                                 "line": 6943,
+---
+>                                 "line": 6947,
+26555c26315
+<                                 "line": 6950,
+---
+>                                 "line": 6954,
+26559c26319
+<                                 "line": 6950,
+---
+>                                 "line": 6954,
+26580c26340
+<                                 "line": 6957,
+---
+>                                 "line": 6961,
+26584c26344
+<                                 "line": 6957,
+---
+>                                 "line": 6961,
+26605c26365
+<                                 "line": 6964,
+---
+>                                 "line": 6968,
+26609c26369
+<                                 "line": 6964,
+---
+>                                 "line": 6968,
+26630c26390
+<                                 "line": 6976,
+---
+>                                 "line": 6980,
+26634c26394
+<                                 "line": 6976,
+---
+>                                 "line": 6980,
+26655c26415
+<                                 "line": 6988,
+---
+>                                 "line": 6992,
+26659c26419
+<                                 "line": 6988,
+---
+>                                 "line": 6992,
+26680c26440
+<                                 "line": 7022,
+---
+>                                 "line": 7026,
+26684c26444
+<                                 "line": 7022,
+---
+>                                 "line": 7026,
+26695c26455
+<                                 "line": 7022,
+---
+>                                 "line": 7026,
+26699c26459
+<                                 "line": 7022,
+---
+>                                 "line": 7026,
+26710c26470
+<                                 "line": 7022,
+---
+>                                 "line": 7026,
+26714c26474
+<                                 "line": 7022,
+---
+>                                 "line": 7026,
+26825c26585
+<                                 "line": 7049,
+---
+>                                 "line": 7053,
+26829c26589
+<                                 "line": 7049,
+---
+>                                 "line": 7053,
+26840c26600
+<                                 "line": 7049,
+---
+>                                 "line": 7053,
+26844c26604
+<                                 "line": 7049,
+---
+>                                 "line": 7053,
+26855c26615
+<                                 "line": 7049,
+---
+>                                 "line": 7053,
+26859c26619
+<                                 "line": 7049,
+---
+>                                 "line": 7053,
+26880c26640
+<                                 "line": 7063,
+---
+>                                 "line": 7067,
+26884c26644
+<                                 "line": 7063,
+---
+>                                 "line": 7067,
+26905c26665
+<                                 "line": 7085,
+---
+>                                 "line": 7089,
+26909c26669
+<                                 "line": 7085,
+---
+>                                 "line": 7089,
+26920c26680
+<                                 "line": 7085,
+---
+>                                 "line": 7089,
+26924c26684
+<                                 "line": 7085,
+---
+>                                 "line": 7089,
+26935c26695
+<                                 "line": 7085,
+---
+>                                 "line": 7089,
+26939c26699
+<                                 "line": 7085,
+---
+>                                 "line": 7089,
+26960c26720
+<                                 "line": 7097,
+---
+>                                 "line": 7101,
+26964c26724
+<                                 "line": 7097,
+---
+>                                 "line": 7101,
+26994c26754
+<                                 "line": 7125,
+---
+>                                 "line": 7129,
+26998c26758
+<                                 "line": 7125,
+---
+>                                 "line": 7129,
+27009c26769
+<                                 "line": 7125,
+---
+>                                 "line": 7129,
+27013c26773
+<                                 "line": 7125,
+---
+>                                 "line": 7129,
+27024c26784
+<                                 "line": 7125,
+---
+>                                 "line": 7129,
+27028c26788
+<                                 "line": 7125,
+---
+>                                 "line": 7129,
+27049c26809
+<                                 "line": 7141,
+---
+>                                 "line": 7145,
+27053c26813
+<                                 "line": 7141,
+---
+>                                 "line": 7145,
+27064c26824
+<                                 "line": 7141,
+---
+>                                 "line": 7145,
+27068c26828
+<                                 "line": 7141,
+---
+>                                 "line": 7145,
+27079c26839
+<                                 "line": 7141,
+---
+>                                 "line": 7145,
+27083c26843
+<                                 "line": 7141,
+---
+>                                 "line": 7145,
+27104c26864
+<                                 "line": 7148,
+---
+>                                 "line": 7152,
+27108c26868
+<                                 "line": 7148,
+---
+>                                 "line": 7152,
+27129c26889
+<                                 "line": 7155,
+---
+>                                 "line": 7159,
+27133c26893
+<                                 "line": 7155,
+---
+>                                 "line": 7159,
+27154c26914
+<                                 "line": 7162,
+---
+>                                 "line": 7166,
+27158c26918
+<                                 "line": 7162,
+---
+>                                 "line": 7166,
+27179c26939
+<                                 "line": 7169,
+---
+>                                 "line": 7173,
+27183c26943
+<                                 "line": 7169,
+---
+>                                 "line": 7173,
+27213c26973
+<                                 "line": 7190,
+---
+>                                 "line": 7194,
+27217c26977
+<                                 "line": 7190,
+---
+>                                 "line": 7194,
+27238c26998
+<                                 "line": 7235,
+---
+>                                 "line": 7239,
+27242c27002
+<                                 "line": 7235,
+---
+>                                 "line": 7239,
+27253c27013
+<                                 "line": 7235,
+---
+>                                 "line": 7239,
+27257c27017
+<                                 "line": 7235,
+---
+>                                 "line": 7239,
+27278c27038
+<                                 "line": 7276,
+---
+>                                 "line": 7280,
+27282c27042
+<                                 "line": 7276,
+---
+>                                 "line": 7280,
+27303c27063
+<                                 "line": 7319,
+---
+>                                 "line": 7323,
+27307c27067
+<                                 "line": 7319,
+---
+>                                 "line": 7323,
+27328c27088
+<                                 "line": 7447,
+---
+>                                 "line": 7451,
+27332c27092
+<                                 "line": 7447,
+---
+>                                 "line": 7451,
+27343c27103
+<                                 "line": 7447,
+---
+>                                 "line": 7451,
+27347c27107
+<                                 "line": 7447,
+---
+>                                 "line": 7451,
+27358c27118
+<                                 "line": 7447,
+---
+>                                 "line": 7451,
+27362c27122
+<                                 "line": 7447,
+---
+>                                 "line": 7451,
+27383c27143
+<                                 "line": 7488,
+---
+>                                 "line": 7492,
+27387c27147
+<                                 "line": 7488,
+---
+>                                 "line": 7492,
+27408c27168
+<                                 "line": 7587,
+---
+>                                 "line": 7591,
+27412c27172
+<                                 "line": 7587,
+---
+>                                 "line": 7591,
+27423c27183
+<                                 "line": 7587,
+---
+>                                 "line": 7591,
+27427c27187
+<                                 "line": 7587,
+---
+>                                 "line": 7591,
+27448c27208
+<                                 "line": 7628,
+---
+>                                 "line": 7632,
+27452c27212
+<                                 "line": 7628,
+---
+>                                 "line": 7632,
+27463c27223
+<                                 "line": 7628,
+---
+>                                 "line": 7632,
+27467c27227
+<                                 "line": 7628,
+---
+>                                 "line": 7632,
+27488c27248
+<                                 "line": 7634,
+---
+>                                 "line": 7638,
+27492c27252
+<                                 "line": 7634,
+---
+>                                 "line": 7638,
+27503c27263
+<                                 "line": 7634,
+---
+>                                 "line": 7638,
+27507c27267
+<                                 "line": 7634,
+---
+>                                 "line": 7638,
+27528c27288
+<                                 "line": 7649,
+---
+>                                 "line": 7653,
+27532c27292
+<                                 "line": 7649,
+---
+>                                 "line": 7653,
+27553c27313
+<                                 "line": 7656,
+---
+>                                 "line": 7660,
+27557c27317
+<                                 "line": 7656,
+---
+>                                 "line": 7660,
+27578c27338
+<                                 "line": 7711,
+---
+>                                 "line": 7715,
+27582c27342
+<                                 "line": 7711,
+---
+>                                 "line": 7715,
+27593c27353
+<                                 "line": 7711,
+---
+>                                 "line": 7715,
+27597c27357
+<                                 "line": 7711,
+---
+>                                 "line": 7715,
+27618c27378
+<                                 "line": 7734,
+---
+>                                 "line": 7738,
+27622c27382
+<                                 "line": 7734,
+---
+>                                 "line": 7738,
+27633c27393
+<                                 "line": 7734,
+---
+>                                 "line": 7738,
+27637c27397
+<                                 "line": 7734,
+---
+>                                 "line": 7738,
+27648c27408
+<                                 "line": 7734,
+---
+>                                 "line": 7738,
+27652c27412
+<                                 "line": 7734,
+---
+>                                 "line": 7738,
+27673c27433
+<                                 "line": 7750,
+---
+>                                 "line": 7754,
+27677c27437
+<                                 "line": 7750,
+---
+>                                 "line": 7754,
+27688c27448
+<                                 "line": 7750,
+---
+>                                 "line": 7754,
+27692c27452
+<                                 "line": 7750,
+---
+>                                 "line": 7754,
+27703c27463
+<                                 "line": 7750,
+---
+>                                 "line": 7754,
+27707c27467
+<                                 "line": 7750,
+---
+>                                 "line": 7754,
+27728c27488
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+27730,27746c27490
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"ndarray[Unknown, Unknown]\"\n    Type argument 1 for class \"ndarray\" has unknown type\n    Type argument 2 for class \"ndarray\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 7764,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 7764,
+<                                 "character": 13
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+27762c27506
+<                                 "line": 7788,
+---
+>                                 "line": 7792,
+27766c27510
+<                                 "line": 7788,
+---
+>                                 "line": 7792,
+27777c27521
+<                                 "line": 7788,
+---
+>                                 "line": 7792,
+27781c27525
+<                                 "line": 7788,
+---
+>                                 "line": 7792,
+27802c27546
+<                                 "line": 7795,
+---
+>                                 "line": 7799,
+27806c27550
+<                                 "line": 7795,
+---
+>                                 "line": 7799,
+27817c27561
+<                                 "line": 7795,
+---
+>                                 "line": 7799,
+27821c27565
+<                                 "line": 7795,
+---
+>                                 "line": 7799,
+27832c27576
+<                                 "line": 7795,
+---
+>                                 "line": 7799,
+27836c27580
+<                                 "line": 7795,
+---
+>                                 "line": 7799,
+27857c27601
+<                                 "line": 7808,
+---
+>                                 "line": 7812,
+27861c27605
+<                                 "line": 7808,
+---
+>                                 "line": 7812,
+27872c27616
+<                                 "line": 7808,
+---
+>                                 "line": 7812,
+27876c27620
+<                                 "line": 7808,
+---
+>                                 "line": 7812,
+27897c27641
+<                                 "line": 7824,
+---
+>                                 "line": 7828,
+27901c27645
+<                                 "line": 7824,
+---
+>                                 "line": 7828,
+27912c27656
+<                                 "line": 7824,
+---
+>                                 "line": 7828,
+27916c27660
+<                                 "line": 7824,
+---
+>                                 "line": 7828,
+27937c27681
+<                                 "line": 7831,
+---
+>                                 "line": 7835,
+27941c27685
+<                                 "line": 7831,
+---
+>                                 "line": 7835,
+27962c27706
+<                                 "line": 7839,
+---
+>                                 "line": 7843,
+27966c27710
+<                                 "line": 7839,
+---
+>                                 "line": 7843,
+27987c27731
+<                                 "line": 7846,
+---
+>                                 "line": 7850,
+27991c27735
+<                                 "line": 7846,
+---
+>                                 "line": 7850,
+28012c27756
+<                                 "line": 7853,
+---
+>                                 "line": 7857,
+28016c27760
+<                                 "line": 7853,
+---
+>                                 "line": 7857,
+28037c27781
+<                                 "line": 7860,
+---
+>                                 "line": 7864,
+28041c27785
+<                                 "line": 7860,
+---
+>                                 "line": 7864,
+28062c27806
+<                                 "line": 7876,
+---
+>                                 "line": 7880,
+28066c27810
+<                                 "line": 7876,
+---
+>                                 "line": 7880,
+28077c27821
+<                                 "line": 7876,
+---
+>                                 "line": 7880,
+28081c27825
+<                                 "line": 7876,
+---
+>                                 "line": 7880,
+28092c27836
+<                                 "line": 7876,
+---
+>                                 "line": 7880,
+28096c27840
+<                                 "line": 7876,
+---
+>                                 "line": 7880,
+28117c27861
+<                                 "line": 7892,
+---
+>                                 "line": 7896,
+28121c27865
+<                                 "line": 7892,
+---
+>                                 "line": 7896,
+28132c27876
+<                                 "line": 7892,
+---
+>                                 "line": 7896,
+28136c27880
+<                                 "line": 7892,
+---
+>                                 "line": 7896,
+28147c27891
+<                                 "line": 7892,
+---
+>                                 "line": 7896,
+28151c27895
+<                                 "line": 7892,
+---
+>                                 "line": 7896,
+28172c27916
+<                                 "line": 7899,
+---
+>                                 "line": 7903,
+28176c27920
+<                                 "line": 7899,
+---
+>                                 "line": 7903,
+28187c27931
+<                                 "line": 7899,
+---
+>                                 "line": 7903,
+28191c27935
+<                                 "line": 7899,
+---
+>                                 "line": 7903,
+28202c27946
+<                                 "line": 7899,
+---
+>                                 "line": 7903,
+28206c27950
+<                                 "line": 7899,
+---
+>                                 "line": 7903,
+28227c27971
+<                                 "line": 7923,
+---
+>                                 "line": 7927,
+28231c27975
+<                                 "line": 7923,
+---
+>                                 "line": 7927,
+28242c27986
+<                                 "line": 7923,
+---
+>                                 "line": 7927,
+28246c27990
+<                                 "line": 7923,
+---
+>                                 "line": 7927,
+28257c28001
+<                                 "line": 7923,
+---
+>                                 "line": 7927,
+28261c28005
+<                                 "line": 7923,
+---
+>                                 "line": 7927,
+28282c28026
+<                                 "line": 7936,
+---
+>                                 "line": 7940,
+28286c28030
+<                                 "line": 7936,
+---
+>                                 "line": 7940,
+28297c28041
+<                                 "line": 7936,
+---
+>                                 "line": 7940,
+28301c28045
+<                                 "line": 7936,
+---
+>                                 "line": 7940,
+28312c28056
+<                                 "line": 7936,
+---
+>                                 "line": 7940,
+28316c28060
+<                                 "line": 7936,
+---
+>                                 "line": 7940,
+28337c28081
+<                                 "line": 7949,
+---
+>                                 "line": 7953,
+28341c28085
+<                                 "line": 7949,
+---
+>                                 "line": 7953,
+28352c28096
+<                                 "line": 7949,
+---
+>                                 "line": 7953,
+28356c28100
+<                                 "line": 7949,
+---
+>                                 "line": 7953,
+28367c28111
+<                                 "line": 7949,
+---
+>                                 "line": 7953,
+28371c28115
+<                                 "line": 7949,
+---
+>                                 "line": 7953,
+28401c28145
+<                                 "line": 7991,
+---
+>                                 "line": 7995,
+28405c28149
+<                                 "line": 7991,
+---
+>                                 "line": 7995,
+28426c28170
+<                                 "line": 8001,
+---
+>                                 "line": 8005,
+28430c28174
+<                                 "line": 8001,
+---
+>                                 "line": 8005,
+28469c28213
+<                                 "line": 8027,
+---
+>                                 "line": 8031,
+28473c28217
+<                                 "line": 8027,
+---
+>                                 "line": 8031,
+28593c28337
+<                                 "line": 8057,
+---
+>                                 "line": 8061,
+28597c28341
+<                                 "line": 8057,
+---
+>                                 "line": 8061,
+28608c28352
+<                                 "line": 8057,
+---
+>                                 "line": 8061,
+28612c28356
+<                                 "line": 8057,
+---
+>                                 "line": 8061,
+28623c28367
+<                                 "line": 8057,
+---
+>                                 "line": 8061,
+28627c28371
+<                                 "line": 8057,
+---
+>                                 "line": 8061,
+28648c28392
+<                                 "line": 8071,
+---
+>                                 "line": 8075,
+28652c28396
+<                                 "line": 8071,
+---
+>                                 "line": 8075,
+28673c28417
+<                                 "line": 8078,
+---
+>                                 "line": 8082,
+28677c28421
+<                                 "line": 8078,
+---
+>                                 "line": 8082,
+28698c28442
+<                                 "line": 8118,
+---
+>                                 "line": 8122,
+28702c28446
+<                                 "line": 8118,
+---
+>                                 "line": 8122,
+28713c28457
+<                                 "line": 8118,
+---
+>                                 "line": 8122,
+28717c28461
+<                                 "line": 8118,
+---
+>                                 "line": 8122,
+28728c28472
+<                                 "line": 8118,
+---
+>                                 "line": 8122,
+28732c28476
+<                                 "line": 8118,
+---
+>                                 "line": 8122,
+28743c28487
+<                                 "line": 8118,
+---
+>                                 "line": 8122,
+28747c28491
+<                                 "line": 8118,
+---
+>                                 "line": 8122,
+28758c28502
+<                                 "line": 8118,
+---
+>                                 "line": 8122,
+28762c28506
+<                                 "line": 8118,
+---
+>                                 "line": 8122,
+28773c28517
+<                                 "line": 8118,
+---
+>                                 "line": 8122,
+28777c28521
+<                                 "line": 8118,
+---
+>                                 "line": 8122,
+28798c28542
+<                                 "line": 8135,
+---
+>                                 "line": 8139,
+28802c28546
+<                                 "line": 8135,
+---
+>                                 "line": 8139,
+28823c28567
+<                                 "line": 8142,
+---
+>                                 "line": 8146,
+28827c28571
+<                                 "line": 8142,
+---
+>                                 "line": 8146,
+28848c28592
+<                                 "line": 8149,
+---
+>                                 "line": 8153,
+28852c28596
+<                                 "line": 8149,
+---
+>                                 "line": 8153,
+28864c28608
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+28866,28882c28610
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"s\" is partially unknown\n  Parameter type is \"Stream\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 8156,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 8156,
+<                                 "character": 21
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+28898c28626
+<                                 "line": 8236,
+---
+>                                 "line": 8240,
+28902c28630
+<                                 "line": 8236,
+---
+>                                 "line": 8240,
+28913c28641
+<                                 "line": 8236,
+---
+>                                 "line": 8240,
+28917c28645
+<                                 "line": 8236,
+---
+>                                 "line": 8240,
+28938c28666
+<                                 "line": 8240,
+---
+>                                 "line": 8244,
+28942c28670
+<                                 "line": 8240,
+---
+>                                 "line": 8244,
+28953c28681
+<                                 "line": 8240,
+---
+>                                 "line": 8244,
+28957c28685
+<                                 "line": 8240,
+---
+>                                 "line": 8244,
+28978c28706
+<                                 "line": 8241,
+---
+>                                 "line": 8245,
+28982c28710
+<                                 "line": 8241,
+---
+>                                 "line": 8245,
+28993c28721
+<                                 "line": 8241,
+---
+>                                 "line": 8245,
+28997c28725
+<                                 "line": 8241,
+---
+>                                 "line": 8245,
+29018c28746
+<                                 "line": 8251,
+---
+>                                 "line": 8255,
+29022c28750
+<                                 "line": 8251,
+---
+>                                 "line": 8255,
+29033c28761
+<                                 "line": 8251,
+---
+>                                 "line": 8255,
+29037c28765
+<                                 "line": 8251,
+---
+>                                 "line": 8255,
+29048c28776
+<                                 "line": 8251,
+---
+>                                 "line": 8255,
+29052c28780
+<                                 "line": 8251,
+---
+>                                 "line": 8255,
+29073c28801
+<                                 "line": 8267,
+---
+>                                 "line": 8271,
+29077c28805
+<                                 "line": 8267,
+---
+>                                 "line": 8271,
+29088c28816
+<                                 "line": 8267,
+---
+>                                 "line": 8271,
+29092c28820
+<                                 "line": 8267,
+---
+>                                 "line": 8271,
+29103c28831
+<                                 "line": 8267,
+---
+>                                 "line": 8271,
+29107c28835
+<                                 "line": 8267,
+---
+>                                 "line": 8271,
+29128c28856
+<                                 "line": 8274,
+---
+>                                 "line": 8278,
+29132c28860
+<                                 "line": 8274,
+---
+>                                 "line": 8278,
+29143c28871
+<                                 "line": 8274,
+---
+>                                 "line": 8278,
+29147c28875
+<                                 "line": 8274,
+---
+>                                 "line": 8278,
+29168c28896
+<                                 "line": 8278,
+---
+>                                 "line": 8282,
+29172c28900
+<                                 "line": 8278,
+---
+>                                 "line": 8282,
+29183c28911
+<                                 "line": 8278,
+---
+>                                 "line": 8282,
+29187c28915
+<                                 "line": 8278,
+---
+>                                 "line": 8282,
+29208c28936
+<                                 "line": 8282,
+---
+>                                 "line": 8286,
+29212c28940
+<                                 "line": 8282,
+---
+>                                 "line": 8286,
+29233c28961
+<                                 "line": 8294,
+---
+>                                 "line": 8298,
+29237c28965
+<                                 "line": 8294,
+---
+>                                 "line": 8298,
+29258c28986
+<                                 "line": 8339,
+---
+>                                 "line": 8343,
+29262c28990
+<                                 "line": 8339,
+---
+>                                 "line": 8343,
+29273c29001
+<                                 "line": 8339,
+---
+>                                 "line": 8343,
+29277c29005
+<                                 "line": 8339,
+---
+>                                 "line": 8343,
+29298c29026
+<                                 "line": 8385,
+---
+>                                 "line": 8389,
+29302c29030
+<                                 "line": 8385,
+---
+>                                 "line": 8389,
+29313c29041
+<                                 "line": 8385,
+---
+>                                 "line": 8389,
+29317c29045
+<                                 "line": 8385,
+---
+>                                 "line": 8389,
+29328c29056
+<                                 "line": 8385,
+---
+>                                 "line": 8389,
+29332c29060
+<                                 "line": 8385,
+---
+>                                 "line": 8389,
+29353c29081
+<                                 "line": 8398,
+---
+>                                 "line": 8402,
+29357c29085
+<                                 "line": 8398,
+---
+>                                 "line": 8402,
+29378c29106
+<                                 "line": 8450,
+---
+>                                 "line": 8454,
+29382c29110
+<                                 "line": 8450,
+---
+>                                 "line": 8454,
+29393c29121
+<                                 "line": 8450,
+---
+>                                 "line": 8454,
+29397c29125
+<                                 "line": 8450,
+---
+>                                 "line": 8454,
+29418c29146
+<                                 "line": 8465,
+---
+>                                 "line": 8469,
+29422c29150
+<                                 "line": 8465,
+---
+>                                 "line": 8469,
+29433c29161
+<                                 "line": 8465,
+---
+>                                 "line": 8469,
+29437c29165
+<                                 "line": 8465,
+---
+>                                 "line": 8469,
+29458c29186
+<                                 "line": 8530,
+---
+>                                 "line": 8534,
+29462c29190
+<                                 "line": 8530,
+---
+>                                 "line": 8534,
+29473c29201
+<                                 "line": 8530,
+---
+>                                 "line": 8534,
+29477c29205
+<                                 "line": 8530,
+---
+>                                 "line": 8534,
+29498c29226
+<                                 "line": 8576,
+---
+>                                 "line": 8580,
+29502c29230
+<                                 "line": 8576,
+---
+>                                 "line": 8580,
+29513c29241
+<                                 "line": 8576,
+---
+>                                 "line": 8580,
+29517c29245
+<                                 "line": 8576,
+---
+>                                 "line": 8580,
+29538c29266
+<                                 "line": 8594,
+---
+>                                 "line": 8598,
+29542c29270
+<                                 "line": 8594,
+---
+>                                 "line": 8598,
+29553c29281
+<                                 "line": 8594,
+---
+>                                 "line": 8598,
+29557c29285
+<                                 "line": 8594,
+---
+>                                 "line": 8598,
+29568c29296
+<                                 "line": 8594,
+---
+>                                 "line": 8598,
+29572c29300
+<                                 "line": 8594,
+---
+>                                 "line": 8598,
+29593c29321
+<                                 "line": 8595,
+---
+>                                 "line": 8599,
+29597c29325
+<                                 "line": 8595,
+---
+>                                 "line": 8599,
+29618c29346
+<                                 "line": 8602,
+---
+>                                 "line": 8606,
+29622c29350
+<                                 "line": 8602,
+---
+>                                 "line": 8606,
+29652c29380
+<                                 "line": 8617,
+---
+>                                 "line": 8621,
+29656c29384
+<                                 "line": 8617,
+---
+>                                 "line": 8621,
+29677c29405
+<                                 "line": 8628,
+---
+>                                 "line": 8632,
+29681c29409
+<                                 "line": 8628,
+---
+>                                 "line": 8632,
+29702c29430
+<                                 "line": 8644,
+---
+>                                 "line": 8648,
+29706c29434
+<                                 "line": 8644,
+---
+>                                 "line": 8648,
+29717c29445
+<                                 "line": 8644,
+---
+>                                 "line": 8648,
+29721c29449
+<                                 "line": 8644,
+---
+>                                 "line": 8648,
+29742c29470
+<                                 "line": 8660,
+---
+>                                 "line": 8664,
+29746c29474
+<                                 "line": 8660,
+---
+>                                 "line": 8664,
+29757c29485
+<                                 "line": 8660,
+---
+>                                 "line": 8664,
+29761c29489
+<                                 "line": 8660,
+---
+>                                 "line": 8664,
+29782c29510
+<                                 "line": 8667,
+---
+>                                 "line": 8671,
+29786c29514
+<                                 "line": 8667,
+---
+>                                 "line": 8671,
+29797c29525
+<                                 "line": 8667,
+---
+>                                 "line": 8671,
+29801c29529
+<                                 "line": 8667,
+---
+>                                 "line": 8671,
+29822c29550
+<                                 "line": 8668,
+---
+>                                 "line": 8672,
+29826c29554
+<                                 "line": 8668,
+---
+>                                 "line": 8672,
+29847c29575
+<                                 "line": 8675,
+---
+>                                 "line": 8679,
+29851c29579
+<                                 "line": 8675,
+---
+>                                 "line": 8679,
+29872c29600
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+29876c29604
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+29887c29615
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+29891c29619
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+29902c29630
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+29906c29634
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+29917c29645
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+29921c29649
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+29932c29660
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+29936c29664
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+29947c29675
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+29951c29679
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+29962c29690
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+29966c29694
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+29977c29705
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+29981c29709
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+29992c29720
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+29996c29724
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+30007c29735
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+30011c29739
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+30022c29750
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+30026c29754
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+30037c29765
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+30041c29769
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+30052c29780
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+30056c29784
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+30067c29795
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+30071c29799
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+30082c29810
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+30086c29814
+<                                 "line": 8747,
+---
+>                                 "line": 8751,
+30107c29835
+<                                 "line": 9155,
+---
+>                                 "line": 9159,
+30111c29839
+<                                 "line": 9155,
+---
+>                                 "line": 9159,
+30122c29850
+<                                 "line": 9155,
+---
+>                                 "line": 9159,
+30126c29854
+<                                 "line": 9155,
+---
+>                                 "line": 9159,
+30137c29865
+<                                 "line": 9155,
+---
+>                                 "line": 9159,
+30141c29869
+<                                 "line": 9155,
+---
+>                                 "line": 9159,
+30152c29880
+<                                 "line": 9155,
+---
+>                                 "line": 9159,
+30156c29884
+<                                 "line": 9155,
+---
+>                                 "line": 9159,
+30167c29895
+<                                 "line": 9155,
+---
+>                                 "line": 9159,
+30171c29899
+<                                 "line": 9155,
+---
+>                                 "line": 9159,
+30182c29910
+<                                 "line": 9155,
+---
+>                                 "line": 9159,
+30186c29914
+<                                 "line": 9155,
+---
+>                                 "line": 9159,
+30197c29925
+<                                 "line": 9155,
+---
+>                                 "line": 9159,
+30201c29929
+<                                 "line": 9155,
+---
+>                                 "line": 9159,
+30212c29940
+<                                 "line": 9155,
+---
+>                                 "line": 9159,
+30216c29944
+<                                 "line": 9155,
+---
+>                                 "line": 9159,
+30227c29955
+<                                 "line": 9155,
+---
+>                                 "line": 9159,
+30231c29959
+<                                 "line": 9155,
+---
+>                                 "line": 9159,
+30242,30477c29970
+<                                 "line": 9155,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9155,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch._C.TensorBase.scatter_add",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"index\" is partially unknown\n  Parameter type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9295,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9295,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"src\" is partially unknown\n  Parameter type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9295,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9295,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9295,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9295,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"index\" is partially unknown\n  Parameter type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9295,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9295,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"src\" is partially unknown\n  Parameter type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9295,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9295,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9295,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9295,
+<                                 "character": 19
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch._C.TensorBase.scatter_add_",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"index\" is partially unknown\n  Parameter type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9307,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9307,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"src\" is partially unknown\n  Parameter type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9307,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9307,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9307,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9307,
+<                                 "character": 20
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch._C.TensorBase.scatter_reduce",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"index\" is partially unknown\n  Parameter type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9360,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9360,
+<                                 "character": 22
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"src\" is partially unknown\n  Parameter type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9360,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9360,
+<                                 "character": 22
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9360,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9360,
+<                                 "character": 22
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch._C.TensorBase.scatter_reduce_",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"index\" is partially unknown\n  Parameter type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9375,
+---
+>                                 "line": 9159,
+30481,30886c29974
+<                                 "line": 9375,
+<                                 "character": 23
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"src\" is partially unknown\n  Parameter type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9375,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9375,
+<                                 "character": 23
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9375,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9375,
+<                                 "character": 23
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch._C.TensorBase.select",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9454,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9454,
+<                                 "character": 14
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9454,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9454,
+<                                 "character": 14
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch._C.TensorBase.select_scatter",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"src\" is partially unknown\n  Parameter type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9461,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9461,
+<                                 "character": 22
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9461,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9461,
+<                                 "character": 22
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch._C.TensorBase.set_",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"source\" is partially unknown\n  Parameter type is \"Storage | TypedStorage | UntypedStorage\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9500,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9500,
+<                                 "character": 12
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9500,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9500,
+<                                 "character": 12
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"source\" is partially unknown\n  Parameter type is \"Storage | TypedStorage | UntypedStorage\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9500,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9500,
+<                                 "character": 12
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9500,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9500,
+<                                 "character": 12
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "class",
+<                 "name": "torch.storage.TypedStorage",
+<                 "referenceCount": 13,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "",
+<                         "severity": "warning",
+<                         "message": "No docstring found for class \"torch.storage.TypedStorage\""
+<                     }
+<                 ],
+<                 "alternateNames": [
+<                     "torch.TypedStorage"
+<                 ]
+<             },
+<             {
+<                 "category": "variable",
+<                 "name": "torch.storage.TypedStorage.is_sparse",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": []
+<             },
+<             {
+<                 "category": "variable",
+<                 "name": "torch.storage.TypedStorage.dtype",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": []
+<             },
+<             {
+<                 "category": "variable",
+<                 "name": "torch.storage.TypedStorage.filename",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": []
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.fill_",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage.TypedStorage.fill_\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 687,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 687,
+<                                 "character": 13
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"value\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 687,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 687,
+<                                 "character": 13
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 687,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 687,
+<                                 "character": 13
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.__new__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"args\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 692,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 692,
+<                                 "character": 15
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"wrap_storage\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 692,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 692,
+<                                 "character": 15
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"dtype\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 692,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 692,
+<                                 "character": 15
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"device\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 692,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 692,
+<                                 "character": 15
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"_internal\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 692,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 692,
+<                                 "character": 15
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 692,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 692,
+<                                 "character": 15
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.__init__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"args\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 784,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 784,
+---
+>                                 "line": 9159,
+30888,33778d29975
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"device\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 784,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 784,
+<                                 "character": 16
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"dtype\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 784,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 784,
+<                                 "character": 16
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"wrap_storage\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 784,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 784,
+<                                 "character": 16
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"_internal\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 784,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 784,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "variable",
+<                 "name": "torch.storage.TypedStorage.is_cuda",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing"
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "variable",
+<                 "name": "torch.storage.TypedStorage.is_hpu",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing"
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.untyped",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 885,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 885,
+<                                 "character": 15
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.__len__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 903,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 903,
+<                                 "character": 15
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.__setitem__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"idx\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 933,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 933,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"value\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 933,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 933,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 933,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 933,
+<                                 "character": 19
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.__getitem__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"idx\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 972,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 972,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 972,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 972,
+<                                 "character": 19
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.copy_",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage.TypedStorage.copy_\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1020,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1020,
+<                                 "character": 13
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1020,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1020,
+<                                 "character": 13
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.nbytes",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage.TypedStorage.nbytes\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1028,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1028,
+<                                 "character": 14
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1028,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1028,
+<                                 "character": 14
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.type",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage.TypedStorage.type\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1036,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1036,
+<                                 "character": 12
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"_StorageBase | TypedStorage | str\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1036,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1036,
+<                                 "character": 12
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "class",
+<                 "name": "torch.storage._StorageBase",
+<                 "referenceCount": 7,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "",
+<                         "severity": "warning",
+<                         "message": "No docstring found for class \"torch.storage._StorageBase\""
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "variable",
+<                 "name": "torch.storage._StorageBase.is_sparse",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": []
+<             },
+<             {
+<                 "category": "variable",
+<                 "name": "torch.storage._StorageBase.is_sparse_csr",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": []
+<             },
+<             {
+<                 "category": "variable",
+<                 "name": "torch.storage._StorageBase.device",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": []
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.__init__",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"args\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 52,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 52,
+<                                 "character": 16
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"kwargs\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 52,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 52,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.__len__",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": []
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.__getitem__",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"idx\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 58,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 58,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 58,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 58,
+<                                 "character": 19
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.__setitem__",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"args\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 61,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 61,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"kwargs\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 61,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 61,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 61,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 61,
+<                                 "character": 19
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.copy_",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage._StorageBase.copy_\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 64,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 64,
+<                                 "character": 13
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.new",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage._StorageBase.new\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 67,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 67,
+<                                 "character": 11
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.nbytes",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage._StorageBase.nbytes\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 70,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 70,
+<                                 "character": 14
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.size",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage._StorageBase.size\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 73,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 73,
+<                                 "character": 12
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.type",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage._StorageBase.type\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 76,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 76,
+<                                 "character": 12
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.cuda",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"device\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 81,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 81,
+<                                 "character": 12
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"non_blocking\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 81,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 81,
+<                                 "character": 12
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.hpu",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"device\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 98,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 98,
+<                                 "character": 11
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"non_blocking\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 98,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 98,
+<                                 "character": 11
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.element_size",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage._StorageBase.element_size\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 113,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 113,
+<                                 "character": 20
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.get_device",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage._StorageBase.get_device\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 116,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 116,
+<                                 "character": 18
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.data_ptr",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage._StorageBase.data_ptr\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 119,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 119,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.resizable",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage._StorageBase.resizable\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 122,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 122,
+<                                 "character": 17
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.from_buffer",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage._StorageBase.from_buffer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 141,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 141,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"args\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 141,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 141,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"kwargs\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 141,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 141,
+<                                 "character": 19
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.resize_",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage._StorageBase.resize_\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 174,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 174,
+<                                 "character": 15
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 174,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 174,
+<                                 "character": 15
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.is_shared",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage._StorageBase.is_shared\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 189,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 189,
+<                                 "character": 17
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "variable",
+<                 "name": "torch.storage._StorageBase.is_cuda",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing"
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "variable",
+<                 "name": "torch.storage._StorageBase.is_hpu",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing"
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.from_file",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage._StorageBase.from_file\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 212,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 212,
+<                                 "character": 17
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"filename\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 212,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 212,
+<                                 "character": 17
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"shared\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 212,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 212,
+<                                 "character": 17
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"nbytes\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 212,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 212,
+<                                 "character": 17
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.__repr__",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 225,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 225,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.__iter__",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 232,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 232,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.__copy__",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 235,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 235,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.__deepcopy__",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"memo\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 238,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 238,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 238,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 238,
+<                                 "character": 20
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.__reduce__",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 246,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 246,
+<                                 "character": 18
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.__sizeof__",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 251,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 251,
+<                                 "character": 18
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.clone",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 254,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 254,
+<                                 "character": 13
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.tolist",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 258,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 258,
+<                                 "character": 14
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.cpu",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 262,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 262,
+<                                 "character": 11
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.mps",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 268,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 268,
+<                                 "character": 11
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.to",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage._StorageBase.to\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 287,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 287,
+<                                 "character": 10
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 287,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 287,
+<                                 "character": 10
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.double",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 292,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 292,
+<                                 "character": 14
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.float",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 296,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 296,
+<                                 "character": 13
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.half",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 300,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 300,
+<                                 "character": 12
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.long",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 304,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 304,
+<                                 "character": 12
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.int",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 308,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 308,
+<                                 "character": 11
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.short",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 312,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 312,
+<                                 "character": 13
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.char",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 316,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 316,
+<                                 "character": 12
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.byte",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 320,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 320,
+<                                 "character": 12
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.bool",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 324,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 324,
+<                                 "character": 12
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.bfloat16",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 328,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 328,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.complex_double",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 332,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 332,
+<                                 "character": 22
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.complex_float",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 336,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 336,
+<                                 "character": 21
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.float8_e5m2",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 340,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 340,
+<                                 "character": 19
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.float8_e4m3fn",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 344,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 344,
+<                                 "character": 21
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.float8_e5m2fnuz",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 348,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 348,
+<                                 "character": 23
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.float8_e4m3fnuz",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 352,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 352,
+<                                 "character": 23
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.is_pinned",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 356,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 356,
+<                                 "character": 17
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.pin_memory",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 372,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 372,
+<                                 "character": 18
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.share_memory_",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 392,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 392,
+<                                 "character": 21
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.untyped",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage._StorageBase.untyped\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 417,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 417,
+<                                 "character": 15
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 417,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 417,
+<                                 "character": 15
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._StorageBase.byteswap",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"dtype\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 420,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 420,
+<                                 "character": 16
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 420,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 420,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.cuda",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage.TypedStorage.cuda\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1053,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1053,
+<                                 "character": 12
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"device\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1053,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1053,
+<                                 "character": 12
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"non_blocking\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1053,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1053,
+<                                 "character": 12
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.hpu",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage.TypedStorage.hpu\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1066,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1066,
+<                                 "character": 11
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"device\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1066,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1066,
+<                                 "character": 11
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"non_blocking\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1066,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1066,
+<                                 "character": 11
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.to",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage.TypedStorage.to\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1079,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1079,
+<                                 "character": 10
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.element_size",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage.TypedStorage.element_size\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1096,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1096,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1096,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1096,
+<                                 "character": 20
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.get_device",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage.TypedStorage.get_device\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1104,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1104,
+<                                 "character": 18
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.__str__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1108,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1108,
+<                                 "character": 15
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.__repr__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1120,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1120,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.__iter__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1124,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1124,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.__copy__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1128,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1128,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.__deepcopy__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"memo\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1132,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1132,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1132,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1132,
+<                                 "character": 20
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.__sizeof__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1140,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1140,
+<                                 "character": 18
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.clone",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1144,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1144,
+<                                 "character": 13
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.tolist",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1149,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1149,
+<                                 "character": 14
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.cpu",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1154,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1154,
+<                                 "character": 11
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.is_pinned",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1159,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1159,
+<                                 "character": 17
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.pin_memory",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1172,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1172,
+<                                 "character": 18
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.share_memory_",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1187,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1187,
+<                                 "character": 21
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "variable",
+<                 "name": "torch.storage.TypedStorage.device",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing"
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.size",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage.TypedStorage.size\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1218,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1218,
+<                                 "character": 12
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1218,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1218,
+<                                 "character": 12
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.pickle_storage_type",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage.TypedStorage.pickle_storage_type\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1228,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1228,
+<                                 "character": 27
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1228,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1228,
+<                                 "character": 27
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.__reduce__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1239,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1239,
+<                                 "character": 18
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.data_ptr",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage.TypedStorage.data_ptr\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1244,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1244,
+<                                 "character": 16
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1244,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1244,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.resizable",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage.TypedStorage.resizable\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1252,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1252,
+<                                 "character": 17
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1252,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1252,
+<                                 "character": 17
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.resize_",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage.TypedStorage.resize_\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1256,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1256,
+<                                 "character": 15
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"size\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1256,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1256,
+<                                 "character": 15
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1256,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1256,
+<                                 "character": 15
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.from_buffer",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage.TypedStorage.from_buffer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1272,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1272,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"args\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1272,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1272,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"kwargs\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1272,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1272,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1272,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1272,
+<                                 "character": 19
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.double",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1321,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1321,
+<                                 "character": 14
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.float",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1326,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1326,
+<                                 "character": 13
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.half",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1331,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1331,
+<                                 "character": 12
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.long",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1336,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1336,
+<                                 "character": 12
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.int",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1341,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1341,
+<                                 "character": 11
+33786c29983
+<                 "name": "torch.storage.TypedStorage.short",
+---
+>                 "name": "torch._C.TensorBase.scatter_add",
+33788c29985
+<                 "isExported": true,
+---
+>                 "isExported": false,
+33793c29990
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+---
+>                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+33795c29992
+<                         "message": "Return type annotation is missing",
+---
+>                         "message": "Type of parameter \"index\" is partially unknown\n  Parameter type is \"Tensor\"",
+33798c29995
+<                                 "line": 1346,
+---
+>                                 "line": 9299,
+33802,33803c29999,30000
+<                                 "line": 1346,
+<                                 "character": 13
+---
+>                                 "line": 9299,
+>                                 "character": 19
+33806,33816c30003
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.char",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+---
+>                     },
+33818c30005
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+---
+>                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+33820c30007
+<                         "message": "Return type annotation is missing",
+---
+>                         "message": "Type of parameter \"src\" is partially unknown\n  Parameter type is \"Tensor\"",
+33823c30010
+<                                 "line": 1351,
+---
+>                                 "line": 9299,
+33827,33828c30014,30015
+<                                 "line": 1351,
+<                                 "character": 12
+---
+>                                 "line": 9299,
+>                                 "character": 19
+33831,33841c30018
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.byte",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+---
+>                     },
+33843c30020
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+---
+>                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+33845c30022
+<                         "message": "Return type annotation is missing",
+---
+>                         "message": "Return type is partially unknown\n  Return type is \"Tensor\"",
+33848c30025
+<                                 "line": 1356,
+---
+>                                 "line": 9299,
+33852,33853c30029,30030
+<                                 "line": 1356,
+<                                 "character": 12
+---
+>                                 "line": 9299,
+>                                 "character": 19
+33856,33866c30033
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.bool",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+---
+>                     },
+33868c30035
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+---
+>                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+33870c30037
+<                         "message": "Return type annotation is missing",
+---
+>                         "message": "Type of parameter \"index\" is partially unknown\n  Parameter type is \"Tensor\"",
+33873c30040
+<                                 "line": 1361,
+---
+>                                 "line": 9299,
+33877,33878c30044,30045
+<                                 "line": 1361,
+<                                 "character": 12
+---
+>                                 "line": 9299,
+>                                 "character": 19
+33881,33891c30048
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.bfloat16",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+---
+>                     },
+33893c30050
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+---
+>                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+33895c30052
+<                         "message": "Return type annotation is missing",
+---
+>                         "message": "Type of parameter \"src\" is partially unknown\n  Parameter type is \"Tensor\"",
+33898c30055
+<                                 "line": 1366,
+---
+>                                 "line": 9299,
+33902,33903c30059,30060
+<                                 "line": 1366,
+<                                 "character": 16
+---
+>                                 "line": 9299,
+>                                 "character": 19
+33906,33916c30063
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.complex_double",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+---
+>                     },
+33918c30065
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+---
+>                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+33920c30067
+<                         "message": "Return type annotation is missing",
+---
+>                         "message": "Return type is partially unknown\n  Return type is \"Tensor\"",
+33923c30070
+<                                 "line": 1371,
+---
+>                                 "line": 9299,
+33927,33928c30074,30075
+<                                 "line": 1371,
+<                                 "character": 22
+---
+>                                 "line": 9299,
+>                                 "character": 19
+33936c30083
+<                 "name": "torch.storage.TypedStorage.complex_float",
+---
+>                 "name": "torch._C.TensorBase.scatter_add_",
+33938c30085
+<                 "isExported": true,
+---
+>                 "isExported": false,
+33943c30090
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+---
+>                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+33945c30092
+<                         "message": "Return type annotation is missing",
+---
+>                         "message": "Type of parameter \"index\" is partially unknown\n  Parameter type is \"Tensor\"",
+33948c30095
+<                                 "line": 1376,
+---
+>                                 "line": 9311,
+33952,33953c30099,30100
+<                                 "line": 1376,
+<                                 "character": 21
+---
+>                                 "line": 9311,
+>                                 "character": 20
+33956,33966c30103
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.float8_e5m2",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+---
+>                     },
+33968c30105
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+---
+>                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+33970c30107
+<                         "message": "Return type annotation is missing",
+---
+>                         "message": "Type of parameter \"src\" is partially unknown\n  Parameter type is \"Tensor\"",
+33973c30110
+<                                 "line": 1381,
+---
+>                                 "line": 9311,
+33977,33978c30114,30115
+<                                 "line": 1381,
+<                                 "character": 19
+---
+>                                 "line": 9311,
+>                                 "character": 20
+33981,33991c30118
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.float8_e4m3fn",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+---
+>                     },
+33993c30120
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+---
+>                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+33995c30122
+<                         "message": "Return type annotation is missing",
+---
+>                         "message": "Return type is partially unknown\n  Return type is \"Tensor\"",
+33998c30125
+<                                 "line": 1386,
+---
+>                                 "line": 9311,
+34002,34003c30129,30130
+<                                 "line": 1386,
+<                                 "character": 21
+---
+>                                 "line": 9311,
+>                                 "character": 20
+34011c30138
+<                 "name": "torch.storage.TypedStorage.float8_e5m2fnuz",
+---
+>                 "name": "torch._C.TensorBase.scatter_reduce",
+34013c30140
+<                 "isExported": true,
+---
+>                 "isExported": false,
+34018c30145
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+---
+>                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+34020c30147
+<                         "message": "Return type annotation is missing",
+---
+>                         "message": "Type of parameter \"index\" is partially unknown\n  Parameter type is \"Tensor\"",
+34023c30150
+<                                 "line": 1391,
+---
+>                                 "line": 9364,
+34027,34028c30154,30155
+<                                 "line": 1391,
+<                                 "character": 23
+---
+>                                 "line": 9364,
+>                                 "character": 22
+34031,34041c30158
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage.TypedStorage.float8_e4m3fnuz",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+---
+>                     },
+34043c30160
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+---
+>                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+34045c30162
+<                         "message": "Return type annotation is missing",
+---
+>                         "message": "Type of parameter \"src\" is partially unknown\n  Parameter type is \"Tensor\"",
+34048c30165
+<                                 "line": 1396,
+---
+>                                 "line": 9364,
+34052,34053c30169,30170
+<                                 "line": 1396,
+<                                 "character": 23
+---
+>                                 "line": 9364,
+>                                 "character": 22
+34055a30173,30187
+>                     },
+>                     {
+>                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+>                         "severity": "error",
+>                         "message": "Return type is partially unknown\n  Return type is \"Tensor\"",
+>                         "range": {
+>                             "start": {
+>                                 "line": 9364,
+>                                 "character": 8
+>                             },
+>                             "end": {
+>                                 "line": 9364,
+>                                 "character": 22
+>                             }
+>                         }
+34061c30193
+<                 "name": "torch.storage.TypedStorage.from_file",
+---
+>                 "name": "torch._C.TensorBase.scatter_reduce_",
+34063c30195
+<                 "isExported": true,
+---
+>                 "isExported": false,
+34068c30200
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+---
+>                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+34070,34085c30202
+<                         "message": "Type annotation for parameter \"filename\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1402,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1402,
+<                                 "character": 17
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"shared\" is missing",
+---
+>                         "message": "Type of parameter \"index\" is partially unknown\n  Parameter type is \"Tensor\"",
+34088c30205
+<                                 "line": 1402,
+---
+>                                 "line": 9379,
+34092,34093c30209,30210
+<                                 "line": 1402,
+<                                 "character": 17
+---
+>                                 "line": 9379,
+>                                 "character": 23
+34098c30215
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+---
+>                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+34100c30217
+<                         "message": "Type annotation for parameter \"size\" is missing",
+---
+>                         "message": "Type of parameter \"src\" is partially unknown\n  Parameter type is \"Tensor\"",
+34103c30220
+<                                 "line": 1402,
+---
+>                                 "line": 9379,
+34107,34108c30224,30225
+<                                 "line": 1402,
+<                                 "character": 17
+---
+>                                 "line": 9379,
+>                                 "character": 23
+34113c30230
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+---
+>                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+34115c30232
+<                         "message": "Return type annotation is missing",
+---
+>                         "message": "Return type is partially unknown\n  Return type is \"Tensor\"",
+34118c30235
+<                                 "line": 1402,
+---
+>                                 "line": 9379,
+34122,34123c30239,30240
+<                                 "line": 1402,
+<                                 "character": 17
+---
+>                                 "line": 9379,
+>                                 "character": 23
+34131c30248
+<                 "name": "torch.storage.TypedStorage.is_shared",
+---
+>                 "name": "torch._C.TensorBase.select",
+34133c30250
+<                 "isExported": true,
+---
+>                 "isExported": false,
+34138,34140c30255,30257
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch.storage.TypedStorage.is_shared\"",
+---
+>                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+>                         "severity": "error",
+>                         "message": "Return type is partially unknown\n  Return type is \"Tensor\"",
+34143c30260
+<                                 "line": 1446,
+---
+>                                 "line": 9458,
+34147,34148c30264,30265
+<                                 "line": 1446,
+<                                 "character": 17
+---
+>                                 "line": 9458,
+>                                 "character": 14
+34153c30270
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+---
+>                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+34155c30272
+<                         "message": "Return type annotation is missing",
+---
+>                         "message": "Return type is partially unknown\n  Return type is \"Tensor\"",
+34158c30275
+<                                 "line": 1446,
+---
+>                                 "line": 9458,
+34162,34163c30279,30280
+<                                 "line": 1446,
+<                                 "character": 17
+---
+>                                 "line": 9458,
+>                                 "character": 14
+34170,34192d30286
+<                 "category": "class",
+<                 "name": "torch.storage.UntypedStorage",
+<                 "referenceCount": 13,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "",
+<                         "severity": "warning",
+<                         "message": "No docstring found for class \"torch.storage.UntypedStorage\""
+<                     },
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Type of base class \"torch.storage._StorageBase\" is partially unknown"
+<                     }
+<                 ],
+<                 "alternateNames": [
+<                     "torch.UntypedStorage"
+<                 ]
+<             },
+<             {
+34194c30288
+<                 "name": "torch.storage.UntypedStorage.__getitem__",
+---
+>                 "name": "torch._C.TensorBase.select_scatter",
+34196c30290
+<                 "isExported": true,
+---
+>                 "isExported": false,
+34201c30295
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+---
+>                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+34203c30297
+<                         "message": "Type annotation for parameter \"args\" is missing",
+---
+>                         "message": "Type of parameter \"src\" is partially unknown\n  Parameter type is \"Tensor\"",
+34206c30300
+<                                 "line": 466,
+---
+>                                 "line": 9465,
+34210,34211c30304,30305
+<                                 "line": 466,
+<                                 "character": 19
+---
+>                                 "line": 9465,
+>                                 "character": 22
+34216c30310
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+---
+>                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+34218c30312
+<                         "message": "Type annotation for parameter \"kwargs\" is missing",
+---
+>                         "message": "Return type is partially unknown\n  Return type is \"Tensor\"",
+34221,34236c30315
+<                                 "line": 466,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 466,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 466,
+---
+>                                 "line": 9465,
+34240,34241c30319,30320
+<                                 "line": 466,
+<                                 "character": 19
+---
+>                                 "line": 9465,
+>                                 "character": 22
+34248,34286d30326
+<                 "category": "variable",
+<                 "name": "torch.storage.UntypedStorage.is_cuda",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing"
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "variable",
+<                 "name": "torch.storage.UntypedStorage.is_hpu",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing"
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "variable",
+<                 "name": "torch.storage.UntypedStorage.filename",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": []
+<             },
+<             {
+34288c30328
+<                 "name": "torch.storage.UntypedStorage.share_memory_",
+---
+>                 "name": "torch._C.TensorBase.set_",
+34290c30330
+<                 "isExported": true,
+---
+>                 "isExported": false,
+34295c30335
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+---
+>                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+34297c30337
+<                         "message": "Type annotation for parameter \"args\" is missing",
+---
+>                         "message": "Return type is partially unknown\n  Return type is \"Tensor\"",
+34300c30340
+<                                 "line": 489,
+---
+>                                 "line": 9504,
+34304,34305c30344,30345
+<                                 "line": 489,
+<                                 "character": 21
+---
+>                                 "line": 9504,
+>                                 "character": 12
+34310c30350
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+---
+>                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+34312c30352
+<                         "message": "Type annotation for parameter \"kwargs\" is missing",
+---
+>                         "message": "Return type is partially unknown\n  Return type is \"Tensor\"",
+34315c30355
+<                                 "line": 489,
+---
+>                                 "line": 9504,
+34319,34320c30359,30360
+<                                 "line": 489,
+<                                 "character": 21
+---
+>                                 "line": 9504,
+>                                 "character": 12
+34323,34337d30362
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 489,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 489,
+<                                 "character": 21
+<                             }
+<                         }
+34342,34359d30366
+<                 "category": "class",
+<                 "name": "torch._C.StorageBase",
+<                 "referenceCount": 2,
+<                 "isExported": false,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "",
+<                         "severity": "warning",
+<                         "message": "No docstring found for class \"torch._C.StorageBase\""
+<                     }
+<                 ],
+<                 "alternateNames": [
+<                     "torch.StorageBase"
+<                 ]
+<             },
+<             {
+34373c30380
+<                                 "line": 9519,
+---
+>                                 "line": 9523,
+34377c30384
+<                                 "line": 9519,
+---
+>                                 "line": 9523,
+34398c30405
+<                                 "line": 9526,
+---
+>                                 "line": 9530,
+34402c30409
+<                                 "line": 9526,
+---
+>                                 "line": 9530,
+34423c30430
+<                                 "line": 9533,
+---
+>                                 "line": 9537,
+34427c30434
+<                                 "line": 9533,
+---
+>                                 "line": 9537,
+34448c30455
+<                                 "line": 9544,
+---
+>                                 "line": 9548,
+34452c30459
+<                                 "line": 9544,
+---
+>                                 "line": 9548,
+34473c30480
+<                                 "line": 9551,
+---
+>                                 "line": 9555,
+34477c30484
+<                                 "line": 9551,
+---
+>                                 "line": 9555,
+34498c30505
+<                                 "line": 9558,
+---
+>                                 "line": 9562,
+34502c30509
+<                                 "line": 9558,
+---
+>                                 "line": 9562,
+34523c30530
+<                                 "line": 9565,
+---
+>                                 "line": 9569,
+34527c30534
+<                                 "line": 9565,
+---
+>                                 "line": 9569,
+34548c30555
+<                                 "line": 9572,
+---
+>                                 "line": 9576,
+34552c30559
+<                                 "line": 9572,
+---
+>                                 "line": 9576,
+34573c30580
+<                                 "line": 9579,
+---
+>                                 "line": 9583,
+34577c30584
+<                                 "line": 9579,
+---
+>                                 "line": 9583,
+34598c30605
+<                                 "line": 9586,
+---
+>                                 "line": 9590,
+34602c30609
+<                                 "line": 9586,
+---
+>                                 "line": 9590,
+34623c30630
+<                                 "line": 9593,
+---
+>                                 "line": 9597,
+34627c30634
+<                                 "line": 9593,
+---
+>                                 "line": 9597,
+34648c30655
+<                                 "line": 9600,
+---
+>                                 "line": 9604,
+34652c30659
+<                                 "line": 9600,
+---
+>                                 "line": 9604,
+34673c30680
+<                                 "line": 9607,
+---
+>                                 "line": 9611,
+34677c30684
+<                                 "line": 9607,
+---
+>                                 "line": 9611,
+34698c30705
+<                                 "line": 9614,
+---
+>                                 "line": 9618,
+34702c30709
+<                                 "line": 9614,
+---
+>                                 "line": 9618,
+34732c30739
+<                                 "line": 9663,
+---
+>                                 "line": 9667,
+34736c30743
+<                                 "line": 9663,
+---
+>                                 "line": 9667,
+34747c30754
+<                                 "line": 9663,
+---
+>                                 "line": 9667,
+34751c30758
+<                                 "line": 9663,
+---
+>                                 "line": 9667,
+34762c30769
+<                                 "line": 9663,
+---
+>                                 "line": 9667,
+34766c30773
+<                                 "line": 9663,
+---
+>                                 "line": 9667,
+34787c30794
+<                                 "line": 9671,
+---
+>                                 "line": 9675,
+34791c30798
+<                                 "line": 9671,
+---
+>                                 "line": 9675,
+34802c30809
+<                                 "line": 9671,
+---
+>                                 "line": 9675,
+34806c30813
+<                                 "line": 9671,
+---
+>                                 "line": 9675,
+34827c30834
+<                                 "line": 9685,
+---
+>                                 "line": 9689,
+34831c30838
+<                                 "line": 9685,
+---
+>                                 "line": 9689,
+34942c30949
+<                                 "line": 9692,
+---
+>                                 "line": 9696,
+34946c30953
+<                                 "line": 9692,
+---
+>                                 "line": 9696,
+34957c30964
+<                                 "line": 9692,
+---
+>                                 "line": 9696,
+34961c30968
+<                                 "line": 9692,
+---
+>                                 "line": 9696,
+34982c30989
+<                                 "line": 9708,
+---
+>                                 "line": 9712,
+34986c30993
+<                                 "line": 9708,
+---
+>                                 "line": 9712,
+34997c31004
+<                                 "line": 9708,
+---
+>                                 "line": 9712,
+35001c31008
+<                                 "line": 9708,
+---
+>                                 "line": 9712,
+35022c31029
+<                                 "line": 9761,
+---
+>                                 "line": 9765,
+35026c31033
+<                                 "line": 9761,
+---
+>                                 "line": 9765,
+35037c31044
+<                                 "line": 9761,
+---
+>                                 "line": 9765,
+35041c31048
+<                                 "line": 9761,
+---
+>                                 "line": 9765,
+35052c31059
+<                                 "line": 9761,
+---
+>                                 "line": 9765,
+35056c31063
+<                                 "line": 9761,
+---
+>                                 "line": 9765,
+35067c31074
+<                                 "line": 9761,
+---
+>                                 "line": 9765,
+35071c31078
+<                                 "line": 9761,
+---
+>                                 "line": 9765,
+35191c31198
+<                                 "line": 9784,
+---
+>                                 "line": 9788,
+35195c31202
+<                                 "line": 9784,
+---
+>                                 "line": 9788,
+35206c31213
+<                                 "line": 9784,
+---
+>                                 "line": 9788,
+35210c31217
+<                                 "line": 9784,
+---
+>                                 "line": 9788,
+35231c31238
+<                                 "line": 9835,
+---
+>                                 "line": 9839,
+35235c31242
+<                                 "line": 9835,
+---
+>                                 "line": 9839,
+35256c31263
+<                                 "line": 9870,
+---
+>                                 "line": 9874,
+35260c31267
+<                                 "line": 9870,
+---
+>                                 "line": 9874,
+35290c31297
+<                                 "line": 9900,
+---
+>                                 "line": 9904,
+35294c31301
+<                                 "line": 9900,
+---
+>                                 "line": 9904,
+35315c31322
+<                                 "line": 9905,
+---
+>                                 "line": 9909,
+35319c31326
+<                                 "line": 9905,
+---
+>                                 "line": 9909,
+35340c31347
+<                                 "line": 9912,
+---
+>                                 "line": 9916,
+35344c31351
+<                                 "line": 9912,
+---
+>                                 "line": 9916,
+35365c31372
+<                                 "line": 9919,
+---
+>                                 "line": 9923,
+35369c31376
+<                                 "line": 9919,
+---
+>                                 "line": 9923,
+35390c31397
+<                                 "line": 9926,
+---
+>                                 "line": 9930,
+35394c31401
+<                                 "line": 9926,
+---
+>                                 "line": 9930,
+35415c31422
+<                                 "line": 9966,
+---
+>                                 "line": 9970,
+35419c31426
+<                                 "line": 9966,
+---
+>                                 "line": 9970,
+35430c31437
+<                                 "line": 9966,
+---
+>                                 "line": 9970,
+35434c31441
+<                                 "line": 9966,
+---
+>                                 "line": 9970,
+35445c31452
+<                                 "line": 9966,
+---
+>                                 "line": 9970,
+35449c31456
+<                                 "line": 9966,
+---
+>                                 "line": 9970,
+35460c31467
+<                                 "line": 9966,
+---
+>                                 "line": 9970,
+35464c31471
+<                                 "line": 9966,
+---
+>                                 "line": 9970,
+35475c31482
+<                                 "line": 9966,
+---
+>                                 "line": 9970,
+35479c31486
+<                                 "line": 9966,
+---
+>                                 "line": 9970,
+35500c31507
+<                                 "line": 10006,
+---
+>                                 "line": 10010,
+35504c31511
+<                                 "line": 10006,
+---
+>                                 "line": 10010,
+35515c31522
+<                                 "line": 10006,
+---
+>                                 "line": 10010,
+35519c31526
+<                                 "line": 10006,
+---
+>                                 "line": 10010,
+35530c31537
+<                                 "line": 10006,
+---
+>                                 "line": 10010,
+35534c31541
+<                                 "line": 10006,
+---
+>                                 "line": 10010,
+35545c31552
+<                                 "line": 10006,
+---
+>                                 "line": 10010,
+35549c31556
+<                                 "line": 10006,
+---
+>                                 "line": 10010,
+35560c31567
+<                                 "line": 10006,
+---
+>                                 "line": 10010,
+35564c31571
+<                                 "line": 10006,
+---
+>                                 "line": 10010,
+35585c31592
+<                                 "line": 10013,
+---
+>                                 "line": 10017,
+35589c31596
+<                                 "line": 10013,
+---
+>                                 "line": 10017,
+35600c31607
+<                                 "line": 10013,
+---
+>                                 "line": 10017,
+35604c31611
+<                                 "line": 10013,
+---
+>                                 "line": 10017,
+35615c31622
+<                                 "line": 10013,
+---
+>                                 "line": 10017,
+35619c31626
+<                                 "line": 10013,
+---
+>                                 "line": 10017,
+35640c31647
+<                                 "line": 10076,
+---
+>                                 "line": 10080,
+35644c31651
+<                                 "line": 10076,
+---
+>                                 "line": 10080,
+35655c31662
+<                                 "line": 10076,
+---
+>                                 "line": 10080,
+35659c31666
+<                                 "line": 10076,
+---
+>                                 "line": 10080,
+35670c31677
+<                                 "line": 10076,
+---
+>                                 "line": 10080,
+35674c31681
+<                                 "line": 10076,
+---
+>                                 "line": 10080,
+35685c31692
+<                                 "line": 10076,
+---
+>                                 "line": 10080,
+35689c31696
+<                                 "line": 10076,
+---
+>                                 "line": 10080,
+35700c31707
+<                                 "line": 10076,
+---
+>                                 "line": 10080,
+35704c31711
+<                                 "line": 10076,
+---
+>                                 "line": 10080,
+35716c31723
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+35725c31732
+<                                 "line": 10089,
+---
+>                                 "line": 10093,
+35729c31736
+<                                 "line": 10089,
+---
+>                                 "line": 10093,
+35733,35747d31739
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"UntypedStorage\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 10089,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 10089,
+<                                 "character": 23
+<                             }
+<                         }
+35774c31766
+<                                 "line": 10106,
+---
+>                                 "line": 10110,
+35778c31770
+<                                 "line": 10106,
+---
+>                                 "line": 10110,
+35808c31800
+<                                 "line": 10159,
+---
+>                                 "line": 10163,
+35812c31804
+<                                 "line": 10159,
+---
+>                                 "line": 10163,
+35823c31815
+<                                 "line": 10159,
+---
+>                                 "line": 10163,
+35827c31819
+<                                 "line": 10159,
+---
+>                                 "line": 10163,
+35838c31830
+<                                 "line": 10159,
+---
+>                                 "line": 10163,
+35842c31834
+<                                 "line": 10159,
+---
+>                                 "line": 10163,
+35863c31855
+<                                 "line": 10172,
+---
+>                                 "line": 10176,
+35867c31859
+<                                 "line": 10172,
+---
+>                                 "line": 10176,
+35878c31870
+<                                 "line": 10172,
+---
+>                                 "line": 10176,
+35882c31874
+<                                 "line": 10172,
+---
+>                                 "line": 10176,
+35903c31895
+<                                 "line": 10198,
+---
+>                                 "line": 10202,
+35907c31899
+<                                 "line": 10198,
+---
+>                                 "line": 10202,
+35918c31910
+<                                 "line": 10198,
+---
+>                                 "line": 10202,
+35922c31914
+<                                 "line": 10198,
+---
+>                                 "line": 10202,
+35933c31925
+<                                 "line": 10198,
+---
+>                                 "line": 10202,
+35937c31929
+<                                 "line": 10198,
+---
+>                                 "line": 10202,
+35958c31950
+<                                 "line": 10223,
+---
+>                                 "line": 10227,
+35962c31954
+<                                 "line": 10223,
+---
+>                                 "line": 10227,
+35973c31965
+<                                 "line": 10223,
+---
+>                                 "line": 10227,
+35977c31969
+<                                 "line": 10223,
+---
+>                                 "line": 10227,
+35988c31980
+<                                 "line": 10223,
+---
+>                                 "line": 10227,
+35992c31984
+<                                 "line": 10223,
+---
+>                                 "line": 10227,
+36013c32005
+<                                 "line": 10257,
+---
+>                                 "line": 10261,
+36017c32009
+<                                 "line": 10257,
+---
+>                                 "line": 10261,
+36028c32020
+<                                 "line": 10257,
+---
+>                                 "line": 10261,
+36032c32024
+<                                 "line": 10257,
+---
+>                                 "line": 10261,
+36043c32035
+<                                 "line": 10257,
+---
+>                                 "line": 10261,
+36047c32039
+<                                 "line": 10257,
+---
+>                                 "line": 10261,
+36068c32060
+<                                 "line": 10283,
+---
+>                                 "line": 10287,
+36072c32064
+<                                 "line": 10283,
+---
+>                                 "line": 10287,
+36083c32075
+<                                 "line": 10283,
+---
+>                                 "line": 10287,
+36087c32079
+<                                 "line": 10283,
+---
+>                                 "line": 10287,
+36108c32100
+<                                 "line": 10294,
+---
+>                                 "line": 10298,
+36112c32104
+<                                 "line": 10294,
+---
+>                                 "line": 10298,
+36238c32230
+<                                 "line": 10305,
+---
+>                                 "line": 10309,
+36242c32234
+<                                 "line": 10305,
+---
+>                                 "line": 10309,
+36263c32255
+<                                 "line": 10312,
+---
+>                                 "line": 10316,
+36267c32259
+<                                 "line": 10312,
+---
+>                                 "line": 10316,
+36288c32280
+<                                 "line": 10319,
+---
+>                                 "line": 10323,
+36292c32284
+<                                 "line": 10319,
+---
+>                                 "line": 10323,
+36313c32305
+<                                 "line": 10326,
+---
+>                                 "line": 10330,
+36317c32309
+<                                 "line": 10326,
+---
+>                                 "line": 10330,
+36338c32330
+<                                 "line": 10333,
+---
+>                                 "line": 10337,
+36342c32334
+<                                 "line": 10333,
+---
+>                                 "line": 10337,
+36363c32355
+<                                 "line": 10340,
+---
+>                                 "line": 10344,
+36367c32359
+<                                 "line": 10340,
+---
+>                                 "line": 10344,
+36388c32380
+<                                 "line": 10347,
+---
+>                                 "line": 10351,
+36392c32384
+<                                 "line": 10347,
+---
+>                                 "line": 10351,
+36403c32395
+<                                 "line": 10347,
+---
+>                                 "line": 10351,
+36407c32399
+<                                 "line": 10347,
+---
+>                                 "line": 10351,
+36428c32420
+<                                 "line": 10354,
+---
+>                                 "line": 10358,
+36432c32424
+<                                 "line": 10354,
+---
+>                                 "line": 10358,
+36443c32435
+<                                 "line": 10354,
+---
+>                                 "line": 10358,
+36447c32439
+<                                 "line": 10354,
+---
+>                                 "line": 10358,
+36468c32460
+<                                 "line": 10365,
+---
+>                                 "line": 10369,
+36472c32464
+<                                 "line": 10365,
+---
+>                                 "line": 10369,
+36493c32485
+<                                 "line": 10372,
+---
+>                                 "line": 10376,
+36497c32489
+<                                 "line": 10372,
+---
+>                                 "line": 10376,
+36518c32510
+<                                 "line": 10379,
+---
+>                                 "line": 10383,
+36522c32514
+<                                 "line": 10379,
+---
+>                                 "line": 10383,
+36543c32535
+<                                 "line": 10386,
+---
+>                                 "line": 10390,
+36547c32539
+<                                 "line": 10386,
+---
+>                                 "line": 10390,
+36568c32560
+<                                 "line": 10418,
+---
+>                                 "line": 10422,
+36572c32564
+<                                 "line": 10418,
+---
+>                                 "line": 10422,
+36593c32585
+<                                 "line": 10438,
+---
+>                                 "line": 10442,
+36597c32589
+<                                 "line": 10438,
+---
+>                                 "line": 10442,
+36608c32600
+<                                 "line": 10438,
+---
+>                                 "line": 10442,
+36612c32604
+<                                 "line": 10438,
+---
+>                                 "line": 10442,
+36633c32625
+<                                 "line": 10645,
+---
+>                                 "line": 10649,
+36637c32629
+<                                 "line": 10645,
+---
+>                                 "line": 10649,
+36648c32640
+<                                 "line": 10645,
+---
+>                                 "line": 10649,
+36652c32644
+<                                 "line": 10645,
+---
+>                                 "line": 10649,
+36663c32655
+<                                 "line": 10645,
+---
+>                                 "line": 10649,
+36667c32659
+<                                 "line": 10645,
+---
+>                                 "line": 10649,
+36678c32670
+<                                 "line": 10645,
+---
+>                                 "line": 10649,
+36682c32674
+<                                 "line": 10645,
+---
+>                                 "line": 10649,
+36703c32695
+<                                 "line": 10743,
+---
+>                                 "line": 10747,
+36707c32699
+<                                 "line": 10743,
+---
+>                                 "line": 10747,
+36728c32720
+<                                 "line": 10773,
+---
+>                                 "line": 10777,
+36732c32724
+<                                 "line": 10773,
+---
+>                                 "line": 10777,
+36753c32745
+<                                 "line": 10779,
+---
+>                                 "line": 10783,
+36757c32749
+<                                 "line": 10779,
+---
+>                                 "line": 10783,
+36778c32770
+<                                 "line": 10884,
+---
+>                                 "line": 10888,
+36782c32774
+<                                 "line": 10884,
+---
+>                                 "line": 10888,
+36793c32785
+<                                 "line": 10884,
+---
+>                                 "line": 10888,
+36797c32789
+<                                 "line": 10884,
+---
+>                                 "line": 10888,
+36818c32810
+<                                 "line": 10971,
+---
+>                                 "line": 10975,
+36822c32814
+<                                 "line": 10971,
+---
+>                                 "line": 10975,
+36843c32835
+<                                 "line": 11026,
+---
+>                                 "line": 11030,
+36847c32839
+<                                 "line": 11026,
+---
+>                                 "line": 11030,
+36868c32860
+<                                 "line": 11081,
+---
+>                                 "line": 11085,
+36872c32864
+<                                 "line": 11081,
+---
+>                                 "line": 11085,
+36893c32885
+<                                 "line": 11118,
+---
+>                                 "line": 11122,
+36897c32889
+<                                 "line": 11118,
+---
+>                                 "line": 11122,
+36909c32901
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+36911,36927c32903
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"list[Unknown]\"\n    Type argument 1 for class \"list\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 11155,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 11155,
+<                                 "character": 14
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+36943c32919
+<                                 "line": 11175,
+---
+>                                 "line": 11179,
+36947c32923
+<                                 "line": 11175,
+---
+>                                 "line": 11179,
+37058c33034
+<                                 "line": 11188,
+---
+>                                 "line": 11192,
+37062c33038
+<                                 "line": 11188,
+---
+>                                 "line": 11192,
+37083c33059
+<                                 "line": 11204,
+---
+>                                 "line": 11208,
+37087c33063
+<                                 "line": 11204,
+---
+>                                 "line": 11208,
+37098c33074
+<                                 "line": 11204,
+---
+>                                 "line": 11208,
+37102c33078
+<                                 "line": 11204,
+---
+>                                 "line": 11208,
+37123c33099
+<                                 "line": 11215,
+---
+>                                 "line": 11219,
+37127c33103
+<                                 "line": 11215,
+---
+>                                 "line": 11219,
+37148c33124
+<                                 "line": 11222,
+---
+>                                 "line": 11226,
+37152c33128
+<                                 "line": 11222,
+---
+>                                 "line": 11226,
+37163c33139
+<                                 "line": 11222,
+---
+>                                 "line": 11226,
+37167c33143
+<                                 "line": 11222,
+---
+>                                 "line": 11226,
+37278c33254
+<                                 "line": 11235,
+---
+>                                 "line": 11239,
+37282c33258
+<                                 "line": 11235,
+---
+>                                 "line": 11239,
+37303c33279
+<                                 "line": 11242,
+---
+>                                 "line": 11246,
+37307c33283
+<                                 "line": 11242,
+---
+>                                 "line": 11246,
+37328c33304
+<                                 "line": 11249,
+---
+>                                 "line": 11253,
+37332c33308
+<                                 "line": 11249,
+---
+>                                 "line": 11253,
+37353c33329
+<                                 "line": 11256,
+---
+>                                 "line": 11260,
+37357c33333
+<                                 "line": 11256,
+---
+>                                 "line": 11260,
+37378c33354
+<                                 "line": 11263,
+---
+>                                 "line": 11267,
+37382c33358
+<                                 "line": 11263,
+---
+>                                 "line": 11267,
+37393c33369
+<                                 "line": 11263,
+---
+>                                 "line": 11267,
+37397c33373
+<                                 "line": 11263,
+---
+>                                 "line": 11267,
+37408c33384
+<                                 "line": 11263,
+---
+>                                 "line": 11267,
+37412c33388
+<                                 "line": 11263,
+---
+>                                 "line": 11267,
+37433c33409
+<                                 "line": 11275,
+---
+>                                 "line": 11279,
+37437c33413
+<                                 "line": 11275,
+---
+>                                 "line": 11279,
+37448c33424
+<                                 "line": 11275,
+---
+>                                 "line": 11279,
+37452c33428
+<                                 "line": 11275,
+---
+>                                 "line": 11279,
+37473c33449
+<                                 "line": 11285,
+---
+>                                 "line": 11289,
+37477c33453
+<                                 "line": 11285,
+---
+>                                 "line": 11289,
+37498c33474
+<                                 "line": 11292,
+---
+>                                 "line": 11296,
+37502c33478
+<                                 "line": 11292,
+---
+>                                 "line": 11296,
+37523c33499
+<                                 "line": 11320,
+---
+>                                 "line": 11324,
+37527c33503
+<                                 "line": 11320,
+---
+>                                 "line": 11324,
+37548c33524
+<                                 "line": 11339,
+---
+>                                 "line": 11343,
+37552c33528
+<                                 "line": 11339,
+---
+>                                 "line": 11343,
+37563c33539
+<                                 "line": 11339,
+---
+>                                 "line": 11343,
+37567c33543
+<                                 "line": 11339,
+---
+>                                 "line": 11343,
+37597c33573
+<                                 "line": 11376,
+---
+>                                 "line": 11380,
+37601c33577
+<                                 "line": 11376,
+---
+>                                 "line": 11380,
+37612c33588
+<                                 "line": 11376,
+---
+>                                 "line": 11380,
+37616c33592
+<                                 "line": 11376,
+---
+>                                 "line": 11380,
+37637c33613
+<                                 "line": 11377,
+---
+>                                 "line": 11381,
+37641c33617
+<                                 "line": 11377,
+---
+>                                 "line": 11381,
+37662c33638
+<                                 "line": 11415,
+---
+>                                 "line": 11419,
+37666c33642
+<                                 "line": 11415,
+---
+>                                 "line": 11419,
+37677c33653
+<                                 "line": 11415,
+---
+>                                 "line": 11419,
+37681c33657
+<                                 "line": 11415,
+---
+>                                 "line": 11419,
+37720c33696
+<                                 "line": 11450,
+---
+>                                 "line": 11454,
+37724c33700
+<                                 "line": 11450,
+---
+>                                 "line": 11454,
+37745c33721
+<                                 "line": 11455,
+---
+>                                 "line": 11459,
+37749c33725
+<                                 "line": 11455,
+---
+>                                 "line": 11459,
+37770c33746
+<                                 "line": 11462,
+---
+>                                 "line": 11466,
+37774c33750
+<                                 "line": 11462,
+---
+>                                 "line": 11466,
+37795c33771
+<                                 "line": 11469,
+---
+>                                 "line": 11473,
+37799c33775
+<                                 "line": 11469,
+---
+>                                 "line": 11473,
+37820c33796
+<                                 "line": 11534,
+---
+>                                 "line": 11538,
+37824c33800
+<                                 "line": 11534,
+---
+>                                 "line": 11538,
+37835c33811
+<                                 "line": 11534,
+---
+>                                 "line": 11538,
+37839c33815
+<                                 "line": 11534,
+---
+>                                 "line": 11538,
+37850c33826
+<                                 "line": 11534,
+---
+>                                 "line": 11538,
+37854c33830
+<                                 "line": 11534,
+---
+>                                 "line": 11538,
+37865c33841
+<                                 "line": 11534,
+---
+>                                 "line": 11538,
+37869c33845
+<                                 "line": 11534,
+---
+>                                 "line": 11538,
+37880c33856
+<                                 "line": 11534,
+---
+>                                 "line": 11538,
+37884c33860
+<                                 "line": 11534,
+---
+>                                 "line": 11538,
+37905c33881
+<                                 "line": 11547,
+---
+>                                 "line": 11551,
+37909c33885
+<                                 "line": 11547,
+---
+>                                 "line": 11551,
+37920c33896
+<                                 "line": 11547,
+---
+>                                 "line": 11551,
+37924c33900
+<                                 "line": 11547,
+---
+>                                 "line": 11551,
+37945c33921
+<                                 "line": 11835,
+---
+>                                 "line": 11839,
+37949c33925
+<                                 "line": 11835,
+---
+>                                 "line": 11839,
+37960c33936
+<                                 "line": 11835,
+---
+>                                 "line": 11839,
+37964c33940
+<                                 "line": 11835,
+---
+>                                 "line": 11839,
+37975c33951
+<                                 "line": 11835,
+---
+>                                 "line": 11839,
+37979c33955
+<                                 "line": 11835,
+---
+>                                 "line": 11839,
+38000c33976
+<                                 "line": 11974,
+---
+>                                 "line": 11978,
+38004c33980
+<                                 "line": 11974,
+---
+>                                 "line": 11978,
+38015c33991
+<                                 "line": 11974,
+---
+>                                 "line": 11978,
+38019c33995
+<                                 "line": 11974,
+---
+>                                 "line": 11978,
+38049c34025
+<                                 "line": 12022,
+---
+>                                 "line": 12026,
+38053c34029
+<                                 "line": 12022,
+---
+>                                 "line": 12026,
+38064c34040
+<                                 "line": 12022,
+---
+>                                 "line": 12026,
+38068c34044
+<                                 "line": 12022,
+---
+>                                 "line": 12026,
+38079c34055
+<                                 "line": 12022,
+---
+>                                 "line": 12026,
+38083c34059
+<                                 "line": 12022,
+---
+>                                 "line": 12026,
+38094c34070
+<                                 "line": 12022,
+---
+>                                 "line": 12026,
+38098c34074
+<                                 "line": 12022,
+---
+>                                 "line": 12026,
+38109c34085
+<                                 "line": 12022,
+---
+>                                 "line": 12026,
+38113c34089
+<                                 "line": 12022,
+---
+>                                 "line": 12026,
+38134c34110
+<                                 "line": 12039,
+---
+>                                 "line": 12043,
+38138c34114
+<                                 "line": 12039,
+---
+>                                 "line": 12043,
+38149c34125
+<                                 "line": 12039,
+---
+>                                 "line": 12043,
+38153c34129
+<                                 "line": 12039,
+---
+>                                 "line": 12043,
+38164c34140
+<                                 "line": 12039,
+---
+>                                 "line": 12043,
+38168c34144
+<                                 "line": 12039,
+---
+>                                 "line": 12043,
+38189c34165
+<                                 "line": 12055,
+---
+>                                 "line": 12059,
+38193c34169
+<                                 "line": 12055,
+---
+>                                 "line": 12059,
+38204c34180
+<                                 "line": 12055,
+---
+>                                 "line": 12059,
+38208c34184
+<                                 "line": 12055,
+---
+>                                 "line": 12059,
+38219c34195
+<                                 "line": 12055,
+---
+>                                 "line": 12059,
+38223c34199
+<                                 "line": 12055,
+---
+>                                 "line": 12059,
+38244c34220
+<                                 "line": 12062,
+---
+>                                 "line": 12066,
+38248c34224
+<                                 "line": 12062,
+---
+>                                 "line": 12066,
+38269c34245
+<                                 "line": 12086,
+---
+>                                 "line": 12090,
+38273c34249
+<                                 "line": 12086,
+---
+>                                 "line": 12090,
+38294c34270
+<                                 "line": 817,
+---
+>                                 "line": 821,
+38298c34274
+<                                 "line": 817,
+---
+>                                 "line": 821,
+38319c34295
+<                                 "line": 818,
+---
+>                                 "line": 822,
+38323c34299
+<                                 "line": 818,
+---
+>                                 "line": 822,
+38344c34320
+<                                 "line": 819,
+---
+>                                 "line": 823,
+38348c34324
+<                                 "line": 819,
+---
+>                                 "line": 823,
+38369c34345
+<                                 "line": 820,
+---
+>                                 "line": 824,
+38373c34349
+<                                 "line": 820,
+---
+>                                 "line": 824,
+38394c34370
+<                                 "line": 821,
+---
+>                                 "line": 825,
+38398c34374
+<                                 "line": 821,
+---
+>                                 "line": 825,
+38419c34395
+<                                 "line": 822,
+---
+>                                 "line": 826,
+38423c34399
+<                                 "line": 822,
+---
+>                                 "line": 826,
+38444c34420
+<                                 "line": 823,
+---
+>                                 "line": 827,
+38448c34424
+<                                 "line": 823,
+---
+>                                 "line": 827,
+38469c34445
+<                                 "line": 824,
+---
+>                                 "line": 828,
+38473c34449
+<                                 "line": 824,
+---
+>                                 "line": 828,
+38494c34470
+<                                 "line": 825,
+---
+>                                 "line": 829,
+38498c34474
+<                                 "line": 825,
+---
+>                                 "line": 829,
+38519c34495
+<                                 "line": 826,
+---
+>                                 "line": 830,
+38523c34499
+<                                 "line": 826,
+---
+>                                 "line": 830,
+38544c34520
+<                                 "line": 827,
+---
+>                                 "line": 831,
+38548c34524
+<                                 "line": 827,
+---
+>                                 "line": 831,
+38569c34545
+<                                 "line": 828,
+---
+>                                 "line": 832,
+38573c34549
+<                                 "line": 828,
+---
+>                                 "line": 832,
+38594c34570
+<                                 "line": 829,
+---
+>                                 "line": 833,
+38598c34574
+<                                 "line": 829,
+---
+>                                 "line": 833,
+38637c34613
+<                                 "line": 847,
+---
+>                                 "line": 851,
+38641c34617
+<                                 "line": 847,
+---
+>                                 "line": 851,
+38662c34638
+<                                 "line": 848,
+---
+>                                 "line": 852,
+38666c34642
+<                                 "line": 848,
+---
+>                                 "line": 852,
+38677c34653
+<                                 "line": 848,
+---
+>                                 "line": 852,
+38681c34657
+<                                 "line": 848,
+---
+>                                 "line": 852,
+38702c34678
+<                                 "line": 849,
+---
+>                                 "line": 853,
+38706c34682
+<                                 "line": 849,
+---
+>                                 "line": 853,
+38727c34703
+<                                 "line": 850,
+---
+>                                 "line": 854,
+38731c34707
+<                                 "line": 850,
+---
+>                                 "line": 854,
+38742c34718
+<                                 "line": 850,
+---
+>                                 "line": 854,
+38746c34722
+<                                 "line": 850,
+---
+>                                 "line": 854,
+38767c34743
+<                                 "line": 851,
+---
+>                                 "line": 855,
+38771c34747
+<                                 "line": 851,
+---
+>                                 "line": 855,
+38792c34768
+<                                 "line": 852,
+---
+>                                 "line": 856,
+38796c34772
+<                                 "line": 852,
+---
+>                                 "line": 856,
+38807c34783
+<                                 "line": 852,
+---
+>                                 "line": 856,
+38811c34787
+<                                 "line": 852,
+---
+>                                 "line": 856,
+38832c34808
+<                                 "line": 853,
+---
+>                                 "line": 857,
+38836c34812
+<                                 "line": 853,
+---
+>                                 "line": 857,
+38857c34833
+<                                 "line": 854,
+---
+>                                 "line": 858,
+38861c34837
+<                                 "line": 854,
+---
+>                                 "line": 858,
+38882c34858
+<                                 "line": 855,
+---
+>                                 "line": 859,
+38886c34862
+<                                 "line": 855,
+---
+>                                 "line": 859,
+38907c34883
+<                                 "line": 856,
+---
+>                                 "line": 860,
+38911c34887
+<                                 "line": 856,
+---
+>                                 "line": 860,
+38922c34898
+<                                 "line": 856,
+---
+>                                 "line": 860,
+38926c34902
+<                                 "line": 856,
+---
+>                                 "line": 860,
+38965c34941
+<                                 "line": 833,
+---
+>                                 "line": 837,
+38969c34945
+<                                 "line": 833,
+---
+>                                 "line": 837,
+38990c34966
+<                                 "line": 834,
+---
+>                                 "line": 838,
+38994c34970
+<                                 "line": 834,
+---
+>                                 "line": 838,
+39015c34991
+<                                 "line": 835,
+---
+>                                 "line": 839,
+39019c34995
+<                                 "line": 835,
+---
+>                                 "line": 839,
+39040c35016
+<                                 "line": 836,
+---
+>                                 "line": 840,
+39044c35020
+<                                 "line": 836,
+---
+>                                 "line": 840,
+39065c35041
+<                                 "line": 837,
+---
+>                                 "line": 841,
+39069c35045
+<                                 "line": 837,
+---
+>                                 "line": 841,
+39090c35066
+<                                 "line": 838,
+---
+>                                 "line": 842,
+39094c35070
+<                                 "line": 838,
+---
+>                                 "line": 842,
+39115c35091
+<                                 "line": 839,
+---
+>                                 "line": 843,
+39119c35095
+<                                 "line": 839,
+---
+>                                 "line": 843,
+39130c35106
+<                                 "line": 839,
+---
+>                                 "line": 843,
+39134c35110
+<                                 "line": 839,
+---
+>                                 "line": 843,
+39155c35131
+<                                 "line": 840,
+---
+>                                 "line": 844,
+39159c35135
+<                                 "line": 840,
+---
+>                                 "line": 844,
+39180c35156
+<                                 "line": 857,
+---
+>                                 "line": 861,
+39184c35160
+<                                 "line": 857,
+---
+>                                 "line": 861,
+39205c35181
+<                                 "line": 858,
+---
+>                                 "line": 862,
+39209c35185
+<                                 "line": 858,
+---
+>                                 "line": 862,
+39230c35206
+<                                 "line": 859,
+---
+>                                 "line": 863,
+39234c35210
+<                                 "line": 859,
+---
+>                                 "line": 863,
+39255c35231
+<                                 "line": 860,
+---
+>                                 "line": 864,
+39259c35235
+<                                 "line": 860,
+---
+>                                 "line": 864,
+39280c35256
+<                                 "line": 861,
+---
+>                                 "line": 865,
+39284c35260
+<                                 "line": 861,
+---
+>                                 "line": 865,
+39295c35271
+<                                 "line": 861,
+---
+>                                 "line": 865,
+39299c35275
+<                                 "line": 861,
+---
+>                                 "line": 865,
+39320c35296
+<                                 "line": 862,
+---
+>                                 "line": 866,
+39324c35300
+<                                 "line": 862,
+---
+>                                 "line": 866,
+39335c35311
+<                                 "line": 862,
+---
+>                                 "line": 866,
+39339c35315
+<                                 "line": 862,
+---
+>                                 "line": 866,
+39350c35326
+<                                 "line": 862,
+---
+>                                 "line": 866,
+39354c35330
+<                                 "line": 862,
+---
+>                                 "line": 866,
+39375c35351
+<                                 "line": 863,
+---
+>                                 "line": 867,
+39379c35355
+<                                 "line": 863,
+---
+>                                 "line": 867,
+39390c35366
+<                                 "line": 863,
+---
+>                                 "line": 867,
+39394c35370
+<                                 "line": 863,
+---
+>                                 "line": 867,
+39405c35381
+<                                 "line": 863,
+---
+>                                 "line": 867,
+39409c35385
+<                                 "line": 863,
+---
+>                                 "line": 867,
+39430c35406
+<                                 "line": 864,
+---
+>                                 "line": 868,
+39434c35410
+<                                 "line": 864,
+---
+>                                 "line": 868,
+39455c35431
+<                                 "line": 865,
+---
+>                                 "line": 869,
+39459c35435
+<                                 "line": 865,
+---
+>                                 "line": 869,
+39480c35456
+<                                 "line": 866,
+---
+>                                 "line": 870,
+39484c35460
+<                                 "line": 866,
+---
+>                                 "line": 870,
+39505c35481
+<                                 "line": 867,
+---
+>                                 "line": 871,
+39509c35485
+<                                 "line": 867,
+---
+>                                 "line": 871,
+39530c35506
+<                                 "line": 868,
+---
+>                                 "line": 872,
+39534c35510
+<                                 "line": 868,
+---
+>                                 "line": 872,
+39555c35531
+<                                 "line": 869,
+---
+>                                 "line": 873,
+39559c35535
+<                                 "line": 869,
+---
+>                                 "line": 873,
+39580c35556
+<                                 "line": 870,
+---
+>                                 "line": 874,
+39584c35560
+<                                 "line": 870,
+---
+>                                 "line": 874,
+39605c35581
+<                                 "line": 871,
+---
+>                                 "line": 875,
+39609c35585
+<                                 "line": 871,
+---
+>                                 "line": 875,
+39630c35606
+<                                 "line": 872,
+---
+>                                 "line": 876,
+39634c35610
+<                                 "line": 872,
+---
+>                                 "line": 876,
+39655c35631
+<                                 "line": 873,
+---
+>                                 "line": 877,
+39659c35635
+<                                 "line": 873,
+---
+>                                 "line": 877,
+39680c35656
+<                                 "line": 874,
+---
+>                                 "line": 878,
+39684c35660
+<                                 "line": 874,
+---
+>                                 "line": 878,
+39705c35681
+<                                 "line": 875,
+---
+>                                 "line": 879,
+39709c35685
+<                                 "line": 875,
+---
+>                                 "line": 879,
+39720c35696
+<                                 "line": 875,
+---
+>                                 "line": 879,
+39724c35700
+<                                 "line": 875,
+---
+>                                 "line": 879,
+39745c35721
+<                                 "line": 876,
+---
+>                                 "line": 880,
+39749c35725
+<                                 "line": 876,
+---
+>                                 "line": 880,
+39770c35746
+<                                 "line": 877,
+---
+>                                 "line": 881,
+39774c35750
+<                                 "line": 877,
+---
+>                                 "line": 881,
+39795c35771
+<                                 "line": 878,
+---
+>                                 "line": 882,
+39799c35775
+<                                 "line": 878,
+---
+>                                 "line": 882,
+39820c35796
+<                                 "line": 879,
+---
+>                                 "line": 883,
+39824c35800
+<                                 "line": 879,
+---
+>                                 "line": 883,
+39845c35821
+<                                 "line": 880,
+---
+>                                 "line": 884,
+39849c35825
+<                                 "line": 880,
+---
+>                                 "line": 884,
+39870c35846
+<                                 "line": 881,
+---
+>                                 "line": 885,
+39874c35850
+<                                 "line": 881,
+---
+>                                 "line": 885,
+39895c35871
+<                                 "line": 882,
+---
+>                                 "line": 886,
+39899c35875
+<                                 "line": 882,
+---
+>                                 "line": 886,
+39920c35896
+<                                 "line": 883,
+---
+>                                 "line": 887,
+39924c35900
+<                                 "line": 883,
+---
+>                                 "line": 887,
+39935c35911
+<                                 "line": 883,
+---
+>                                 "line": 887,
+39939c35915
+<                                 "line": 883,
+---
+>                                 "line": 887,
+39960c35936
+<                                 "line": 884,
+---
+>                                 "line": 888,
+39964c35940
+<                                 "line": 884,
+---
+>                                 "line": 888,
+40003c35979
+<                                 "line": 885,
+---
+>                                 "line": 889,
+40007c35983
+<                                 "line": 885,
+---
+>                                 "line": 889,
+40018c35994
+<                                 "line": 885,
+---
+>                                 "line": 889,
+40022c35998
+<                                 "line": 885,
+---
+>                                 "line": 889,
+40043c36019
+<                                 "line": 886,
+---
+>                                 "line": 890,
+40047c36023
+<                                 "line": 886,
+---
+>                                 "line": 890,
+40068c36044
+<                                 "line": 887,
+---
+>                                 "line": 891,
+40072c36048
+<                                 "line": 887,
+---
+>                                 "line": 891,
+40093c36069
+<                                 "line": 888,
+---
+>                                 "line": 892,
+40097c36073
+<                                 "line": 888,
+---
+>                                 "line": 892,
+40118c36094
+<                                 "line": 889,
+---
+>                                 "line": 893,
+40122c36098
+<                                 "line": 889,
+---
+>                                 "line": 893,
+40143c36119
+<                                 "line": 890,
+---
+>                                 "line": 894,
+40147c36123
+<                                 "line": 890,
+---
+>                                 "line": 894,
+40168c36144
+<                                 "line": 891,
+---
+>                                 "line": 895,
+40172c36148
+<                                 "line": 891,
+---
+>                                 "line": 895,
+40193c36169
+<                                 "line": 894,
+---
+>                                 "line": 898,
+40197c36173
+<                                 "line": 894,
+---
+>                                 "line": 898,
+40218c36194
+<                                 "line": 895,
+---
+>                                 "line": 899,
+40222c36198
+<                                 "line": 895,
+---
+>                                 "line": 899,
+40243c36219
+<                                 "line": 896,
+---
+>                                 "line": 900,
+40247c36223
+<                                 "line": 896,
+---
+>                                 "line": 900,
+40268c36244
+<                                 "line": 897,
+---
+>                                 "line": 901,
+40272c36248
+<                                 "line": 897,
+---
+>                                 "line": 901,
+40293c36269
+<                                 "line": 898,
+---
+>                                 "line": 902,
+40297c36273
+<                                 "line": 898,
+---
+>                                 "line": 902,
+40318c36294
+<                                 "line": 899,
+---
+>                                 "line": 903,
+40322c36298
+<                                 "line": 899,
+---
+>                                 "line": 903,
+40343c36319
+<                                 "line": 900,
+---
+>                                 "line": 904,
+40347c36323
+<                                 "line": 900,
+---
+>                                 "line": 904,
+40368c36344
+<                                 "line": 901,
+---
+>                                 "line": 905,
+40372c36348
+<                                 "line": 901,
+---
+>                                 "line": 905,
+40393c36369
+<                                 "line": 902,
+---
+>                                 "line": 906,
+40397c36373
+<                                 "line": 902,
+---
+>                                 "line": 906,
+40418c36394
+<                                 "line": 903,
+---
+>                                 "line": 907,
+40422c36398
+<                                 "line": 903,
+---
+>                                 "line": 907,
+40443c36419
+<                                 "line": 904,
+---
+>                                 "line": 908,
+40447c36423
+<                                 "line": 904,
+---
+>                                 "line": 908,
+40468c36444
+<                                 "line": 905,
+---
+>                                 "line": 909,
+40472c36448
+<                                 "line": 905,
+---
+>                                 "line": 909,
+40493c36469
+<                                 "line": 909,
+---
+>                                 "line": 913,
+40497c36473
+<                                 "line": 909,
+---
+>                                 "line": 913,
+40518c36494
+<                                 "line": 910,
+---
+>                                 "line": 914,
+40522c36498
+<                                 "line": 910,
+---
+>                                 "line": 914,
+40543c36519
+<                                 "line": 911,
+---
+>                                 "line": 915,
+40547c36523
+<                                 "line": 911,
+---
+>                                 "line": 915,
+40568c36544
+<                                 "line": 912,
+---
+>                                 "line": 916,
+40572c36548
+<                                 "line": 912,
+---
+>                                 "line": 916,
+40593c36569
+<                                 "line": 913,
+---
+>                                 "line": 917,
+40597c36573
+<                                 "line": 913,
+---
+>                                 "line": 917,
+40618c36594
+<                                 "line": 914,
+---
+>                                 "line": 918,
+40622c36598
+<                                 "line": 914,
+---
+>                                 "line": 918,
+40643c36619
+<                                 "line": 915,
+---
+>                                 "line": 919,
+40647c36623
+<                                 "line": 915,
+---
+>                                 "line": 919,
+40658c36634
+<                                 "line": 915,
+---
+>                                 "line": 919,
+40662c36638
+<                                 "line": 915,
+---
+>                                 "line": 919,
+40683c36659
+<                                 "line": 916,
+---
+>                                 "line": 920,
+40687c36663
+<                                 "line": 916,
+---
+>                                 "line": 920,
+40698c36674
+<                                 "line": 916,
+---
+>                                 "line": 920,
+40702c36678
+<                                 "line": 916,
+---
+>                                 "line": 920,
+40723c36699
+<                                 "line": 917,
+---
+>                                 "line": 921,
+40727c36703
+<                                 "line": 917,
+---
+>                                 "line": 921,
+40748c36724
+<                                 "line": 918,
+---
+>                                 "line": 922,
+40752c36728
+<                                 "line": 918,
+---
+>                                 "line": 922,
+40773c36749
+<                                 "line": 919,
+---
+>                                 "line": 923,
+40777c36753
+<                                 "line": 919,
+---
+>                                 "line": 923,
+40798c36774
+<                                 "line": 920,
+---
+>                                 "line": 924,
+40802c36778
+<                                 "line": 920,
+---
+>                                 "line": 924,
+40823c36799
+<                                 "line": 921,
+---
+>                                 "line": 925,
+40827c36803
+<                                 "line": 921,
+---
+>                                 "line": 925,
+40848c36824
+<                                 "line": 922,
+---
+>                                 "line": 926,
+40852c36828
+<                                 "line": 922,
+---
+>                                 "line": 926,
+40873c36849
+<                                 "line": 930,
+---
+>                                 "line": 934,
+40877c36853
+<                                 "line": 930,
+---
+>                                 "line": 934,
+40888c36864
+<                                 "line": 930,
+---
+>                                 "line": 934,
+40892c36868
+<                                 "line": 930,
+---
+>                                 "line": 934,
+40913c36889
+<                                 "line": 931,
+---
+>                                 "line": 935,
+40917c36893
+<                                 "line": 931,
+---
+>                                 "line": 935,
+40928c36904
+<                                 "line": 931,
+---
+>                                 "line": 935,
+40932c36908
+<                                 "line": 931,
+---
+>                                 "line": 935,
+40953c36929
+<                                 "line": 932,
+---
+>                                 "line": 936,
+40957c36933
+<                                 "line": 932,
+---
+>                                 "line": 936,
+40978c36954
+<                                 "line": 933,
+---
+>                                 "line": 937,
+40982c36958
+<                                 "line": 933,
+---
+>                                 "line": 937,
+40993c36969
+<                                 "line": 933,
+---
+>                                 "line": 937,
+40997c36973
+<                                 "line": 933,
+---
+>                                 "line": 937,
+41018c36994
+<                                 "line": 934,
+---
+>                                 "line": 938,
+41022c36998
+<                                 "line": 934,
+---
+>                                 "line": 938,
+41043c37019
+<                                 "line": 935,
+---
+>                                 "line": 939,
+41047c37023
+<                                 "line": 935,
+---
+>                                 "line": 939,
+41058c37034
+<                                 "line": 935,
+---
+>                                 "line": 939,
+41062c37038
+<                                 "line": 935,
+---
+>                                 "line": 939,
+41073c37049
+<                                 "line": 935,
+---
+>                                 "line": 939,
+41077c37053
+<                                 "line": 935,
+---
+>                                 "line": 939,
+41098c37074
+<                                 "line": 936,
+---
+>                                 "line": 940,
+41102c37078
+<                                 "line": 936,
+---
+>                                 "line": 940,
+41113c37089
+<                                 "line": 936,
+---
+>                                 "line": 940,
+41117c37093
+<                                 "line": 936,
+---
+>                                 "line": 940,
+41128c37104
+<                                 "line": 936,
+---
+>                                 "line": 940,
+41132c37108
+<                                 "line": 936,
+---
+>                                 "line": 940,
+41153c37129
+<                                 "line": 937,
+---
+>                                 "line": 941,
+41157c37133
+<                                 "line": 937,
+---
+>                                 "line": 941,
+41168c37144
+<                                 "line": 937,
+---
+>                                 "line": 941,
+41172c37148
+<                                 "line": 937,
+---
+>                                 "line": 941,
+41183c37159
+<                                 "line": 937,
+---
+>                                 "line": 941,
+41187c37163
+<                                 "line": 937,
+---
+>                                 "line": 941,
+41208c37184
+<                                 "line": 938,
+---
+>                                 "line": 942,
+41212c37188
+<                                 "line": 938,
+---
+>                                 "line": 942,
+41223c37199
+<                                 "line": 938,
+---
+>                                 "line": 942,
+41227c37203
+<                                 "line": 938,
+---
+>                                 "line": 942,
+41238c37214
+<                                 "line": 938,
+---
+>                                 "line": 942,
+41242c37218
+<                                 "line": 938,
+---
+>                                 "line": 942,
+41263c37239
+<                                 "line": 939,
+---
+>                                 "line": 943,
+41267c37243
+<                                 "line": 939,
+---
+>                                 "line": 943,
+41278c37254
+<                                 "line": 939,
+---
+>                                 "line": 943,
+41282c37258
+<                                 "line": 939,
+---
+>                                 "line": 943,
+41303c37279
+<                                 "line": 940,
+---
+>                                 "line": 944,
+41307c37283
+<                                 "line": 940,
+---
+>                                 "line": 944,
+41328c37304
+<                                 "line": 941,
+---
+>                                 "line": 945,
+41332c37308
+<                                 "line": 941,
+---
+>                                 "line": 945,
+41371c37347
+<                                 "line": 942,
+---
+>                                 "line": 946,
+41375c37351
+<                                 "line": 942,
+---
+>                                 "line": 946,
+41386c37362
+<                                 "line": 942,
+---
+>                                 "line": 946,
+41390c37366
+<                                 "line": 942,
+---
+>                                 "line": 946,
+41411c37387
+<                                 "line": 943,
+---
+>                                 "line": 947,
+41415c37391
+<                                 "line": 943,
+---
+>                                 "line": 947,
+41426c37402
+<                                 "line": 943,
+---
+>                                 "line": 947,
+41430c37406
+<                                 "line": 943,
+---
+>                                 "line": 947,
+41484c37460
+<                                 "line": 944,
+---
+>                                 "line": 948,
+41488c37464
+<                                 "line": 944,
+---
+>                                 "line": 948,
+41499c37475
+<                                 "line": 944,
+---
+>                                 "line": 948,
+41503c37479
+<                                 "line": 944,
+---
+>                                 "line": 948,
+41524c37500
+<                                 "line": 945,
+---
+>                                 "line": 949,
+41528c37504
+<                                 "line": 945,
+---
+>                                 "line": 949,
+41549c37525
+<                                 "line": 946,
+---
+>                                 "line": 950,
+41553c37529
+<                                 "line": 946,
+---
+>                                 "line": 950,
+41574c37550
+<                                 "line": 947,
+---
+>                                 "line": 951,
+41578c37554
+<                                 "line": 947,
+---
+>                                 "line": 951,
+41749c37725
+<                                 "line": 1085,
+---
+>                                 "line": 1089,
+41753c37729
+<                                 "line": 1085,
+---
+>                                 "line": 1089,
+41774c37750
+<                                 "line": 1086,
+---
+>                                 "line": 1090,
+41778c37754
+<                                 "line": 1086,
+---
+>                                 "line": 1090,
+41789c37765
+<                                 "line": 1086,
+---
+>                                 "line": 1090,
+41793c37769
+<                                 "line": 1086,
+---
+>                                 "line": 1090,
+41841c37817
+<                                 "line": 1122,
+---
+>                                 "line": 1126,
+41845c37821
+<                                 "line": 1122,
+---
+>                                 "line": 1126,
+41866c37842
+<                                 "line": 1123,
+---
+>                                 "line": 1127,
+41870c37846
+<                                 "line": 1123,
+---
+>                                 "line": 1127,
+41906c37882
+<                                 "line": 1126,
+---
+>                                 "line": 1130,
+41910c37886
+<                                 "line": 1126,
+---
+>                                 "line": 1130,
+41921c37897
+<                                 "line": 1126,
+---
+>                                 "line": 1130,
+41925c37901
+<                                 "line": 1126,
+---
+>                                 "line": 1130,
+41946c37922
+<                                 "line": 1127,
+---
+>                                 "line": 1131,
+41950c37926
+<                                 "line": 1127,
+---
+>                                 "line": 1131,
+41971c37947
+<                                 "line": 1128,
+---
+>                                 "line": 1132,
+41975c37951
+<                                 "line": 1128,
+---
+>                                 "line": 1132,
+41996c37972
+<                                 "line": 1129,
+---
+>                                 "line": 1133,
+42000c37976
+<                                 "line": 1129,
+---
+>                                 "line": 1133,
+42030c38006
+<                                 "line": 1087,
+---
+>                                 "line": 1091,
+42034c38010
+<                                 "line": 1087,
+---
+>                                 "line": 1091,
+42055c38031
+<                                 "line": 1088,
+---
+>                                 "line": 1092,
+42059c38035
+<                                 "line": 1088,
+---
+>                                 "line": 1092,
+42070c38046
+<                                 "line": 1088,
+---
+>                                 "line": 1092,
+42074c38050
+<                                 "line": 1088,
+---
+>                                 "line": 1092,
+42085c38061
+<                                 "line": 1088,
+---
+>                                 "line": 1092,
+42089c38065
+<                                 "line": 1088,
+---
+>                                 "line": 1092,
+42110c38086
+<                                 "line": 1094,
+---
+>                                 "line": 1098,
+42114c38090
+<                                 "line": 1094,
+---
+>                                 "line": 1098,
+42162c38138
+<                                 "line": 12754,
+---
+>                                 "line": 12758,
+42166c38142
+<                                 "line": 12754,
+---
+>                                 "line": 12758,
+42187c38163
+<                                 "line": 12755,
+---
+>                                 "line": 12759,
+42191c38167
+<                                 "line": 12755,
+---
+>                                 "line": 12759,
+42212c38188
+<                                 "line": 1095,
+---
+>                                 "line": 1099,
+42216c38192
+<                                 "line": 1095,
+---
+>                                 "line": 1099,
+42227c38203
+<                                 "line": 1095,
+---
+>                                 "line": 1099,
+42231c38207
+<                                 "line": 1095,
+---
+>                                 "line": 1099,
+42252c38228
+<                                 "line": 1096,
+---
+>                                 "line": 1100,
+42256c38232
+<                                 "line": 1096,
+---
+>                                 "line": 1100,
+42267c38243
+<                                 "line": 1096,
+---
+>                                 "line": 1100,
+42271c38247
+<                                 "line": 1096,
+---
+>                                 "line": 1100,
+42282c38258
+<                                 "line": 1096,
+---
+>                                 "line": 1100,
+42286c38262
+<                                 "line": 1096,
+---
+>                                 "line": 1100,
+42297c38273
+<                                 "line": 1096,
+---
+>                                 "line": 1100,
+42301c38277
+<                                 "line": 1096,
+---
+>                                 "line": 1100,
+42322c38298
+<                                 "line": 1102,
+---
+>                                 "line": 1106,
+42326c38302
+<                                 "line": 1102,
+---
+>                                 "line": 1106,
+42374c38350
+<                                 "line": 12750,
+---
+>                                 "line": 12754,
+42378c38354
+<                                 "line": 12750,
+---
+>                                 "line": 12754,
+42440c38416
+<                                 "line": 1105,
+---
+>                                 "line": 1109,
+42444c38420
+<                                 "line": 1105,
+---
+>                                 "line": 1109,
+42455c38431
+<                                 "line": 1105,
+---
+>                                 "line": 1109,
+42459c38435
+<                                 "line": 1105,
+---
+>                                 "line": 1109,
+42610c38586
+<                                 "line": 809,
+---
+>                                 "line": 813,
+42614c38590
+<                                 "line": 809,
+---
+>                                 "line": 813,
+42824c38800
+<                                 "line": 966,
+---
+>                                 "line": 970,
+42828c38804
+<                                 "line": 966,
+---
+>                                 "line": 970,
+42987c38963
+<                                 "line": 1657,
+---
+>                                 "line": 1661,
+42991c38967
+<                                 "line": 1657,
+---
+>                                 "line": 1661,
+43012c38988
+<                                 "line": 1663,
+---
+>                                 "line": 1667,
+43016c38992
+<                                 "line": 1663,
+---
+>                                 "line": 1667,
+43037c39013
+<                                 "line": 1664,
+---
+>                                 "line": 1668,
+43041c39017
+<                                 "line": 1664,
+---
+>                                 "line": 1668,
+43062c39038
+<                                 "line": 1665,
+---
+>                                 "line": 1669,
+43066c39042
+<                                 "line": 1665,
+---
+>                                 "line": 1669,
+43087c39063
+<                                 "line": 1666,
+---
+>                                 "line": 1670,
+43091c39067
+<                                 "line": 1666,
+---
+>                                 "line": 1670,
+43112c39088
+<                                 "line": 1667,
+---
+>                                 "line": 1671,
+43116c39092
+<                                 "line": 1667,
+---
+>                                 "line": 1671,
+43137c39113
+<                                 "line": 1022,
+---
+>                                 "line": 1026,
+43141c39117
+<                                 "line": 1022,
+---
+>                                 "line": 1026,
+43152c39128
+<                                 "line": 1022,
+---
+>                                 "line": 1026,
+43156c39132
+<                                 "line": 1022,
+---
+>                                 "line": 1026,
+43177c39153
+<                                 "line": 1023,
+---
+>                                 "line": 1027,
+43181c39157
+<                                 "line": 1023,
+---
+>                                 "line": 1027,
+43202c39178
+<                                 "line": 1024,
+---
+>                                 "line": 1028,
+43206c39182
+<                                 "line": 1024,
+---
+>                                 "line": 1028,
+43254c39230
+<                                 "line": 1029,
+---
+>                                 "line": 1033,
+43258c39234
+<                                 "line": 1029,
+---
+>                                 "line": 1033,
+43279c39255
+<                                 "line": 1030,
+---
+>                                 "line": 1034,
+43283c39259
+<                                 "line": 1030,
+---
+>                                 "line": 1034,
+43361c39337
+<                                 "line": 1035,
+---
+>                                 "line": 1039,
+43365c39341
+<                                 "line": 1035,
+---
+>                                 "line": 1039,
+43376c39352
+<                                 "line": 1035,
+---
+>                                 "line": 1039,
+43380c39356
+<                                 "line": 1035,
+---
+>                                 "line": 1039,
+43401c39377
+<                                 "line": 1036,
+---
+>                                 "line": 1040,
+43405c39381
+<                                 "line": 1036,
+---
+>                                 "line": 1040,
+43426c39402
+<                                 "line": 1037,
+---
+>                                 "line": 1041,
+43430c39406
+<                                 "line": 1037,
+---
+>                                 "line": 1041,
+43441c39417
+<                                 "line": 1037,
+---
+>                                 "line": 1041,
+43445c39421
+<                                 "line": 1037,
+---
+>                                 "line": 1041,
+43508c39484
+<                                 "line": 1042,
+---
+>                                 "line": 1046,
+43512c39488
+<                                 "line": 1042,
+---
+>                                 "line": 1046,
+43523c39499
+<                                 "line": 1042,
+---
+>                                 "line": 1046,
+43527c39503
+<                                 "line": 1042,
+---
+>                                 "line": 1046,
+43548c39524
+<                                 "line": 1043,
+---
+>                                 "line": 1047,
+43552c39528
+<                                 "line": 1043,
+---
+>                                 "line": 1047,
+43563c39539
+<                                 "line": 1043,
+---
+>                                 "line": 1047,
+43567c39543
+<                                 "line": 1043,
+---
+>                                 "line": 1047,
+43588c39564
+<                                 "line": 1044,
+---
+>                                 "line": 1048,
+43592c39568
+<                                 "line": 1044,
+---
+>                                 "line": 1048,
+43603c39579
+<                                 "line": 1044,
+---
+>                                 "line": 1048,
+43607c39583
+<                                 "line": 1044,
+---
+>                                 "line": 1048,
+43628c39604
+<                                 "line": 1045,
+---
+>                                 "line": 1049,
+43632c39608
+<                                 "line": 1045,
+---
+>                                 "line": 1049,
+43643c39619
+<                                 "line": 1045,
+---
+>                                 "line": 1049,
+43647c39623
+<                                 "line": 1045,
+---
+>                                 "line": 1049,
+43668c39644
+<                                 "line": 1046,
+---
+>                                 "line": 1050,
+43672c39648
+<                                 "line": 1046,
+---
+>                                 "line": 1050,
+43683c39659
+<                                 "line": 1046,
+---
+>                                 "line": 1050,
+43687c39663
+<                                 "line": 1046,
+---
+>                                 "line": 1050,
+43708c39684
+<                                 "line": 1053,
+---
+>                                 "line": 1057,
+43712c39688
+<                                 "line": 1053,
+---
+>                                 "line": 1057,
+43723c39699
+<                                 "line": 1053,
+---
+>                                 "line": 1057,
+43727c39703
+<                                 "line": 1053,
+---
+>                                 "line": 1057,
+43766c39742
+<                                 "line": 1070,
+---
+>                                 "line": 1074,
+43770c39746
+<                                 "line": 1070,
+---
+>                                 "line": 1074,
+43791c39767
+<                                 "line": 1071,
+---
+>                                 "line": 1075,
+43795c39771
+<                                 "line": 1071,
+---
+>                                 "line": 1075,
+43816c39792
+<                                 "line": 1073,
+---
+>                                 "line": 1077,
+43820c39796
+<                                 "line": 1073,
+---
+>                                 "line": 1077,
+43841c39817
+<                                 "line": 1054,
+---
+>                                 "line": 1058,
+43845c39821
+<                                 "line": 1054,
+---
+>                                 "line": 1058,
+43856c39832
+<                                 "line": 1054,
+---
+>                                 "line": 1058,
+43860c39836
+<                                 "line": 1054,
+---
+>                                 "line": 1058,
+43881c39857
+<                                 "line": 1055,
+---
+>                                 "line": 1059,
+43885c39861
+<                                 "line": 1055,
+---
+>                                 "line": 1059,
+43896c39872
+<                                 "line": 1055,
+---
+>                                 "line": 1059,
+43900c39876
+<                                 "line": 1055,
+---
+>                                 "line": 1059,
+43921c39897
+<                                 "line": 1056,
+---
+>                                 "line": 1060,
+43925c39901
+<                                 "line": 1056,
+---
+>                                 "line": 1060,
+43936c39912
+<                                 "line": 1056,
+---
+>                                 "line": 1060,
+43940c39916
+<                                 "line": 1056,
+---
+>                                 "line": 1060,
+43961c39937
+<                                 "line": 1057,
+---
+>                                 "line": 1061,
+43965c39941
+<                                 "line": 1057,
+---
+>                                 "line": 1061,
+43976c39952
+<                                 "line": 1057,
+---
+>                                 "line": 1061,
+43980c39956
+<                                 "line": 1057,
+---
+>                                 "line": 1061,
+44001c39977
+<                                 "line": 1058,
+---
+>                                 "line": 1062,
+44005c39981
+<                                 "line": 1058,
+---
+>                                 "line": 1062,
+44016c39992
+<                                 "line": 1058,
+---
+>                                 "line": 1062,
+44020c39996
+<                                 "line": 1058,
+---
+>                                 "line": 1062,
+44041c40017
+<                                 "line": 1064,
+---
+>                                 "line": 1068,
+44045c40021
+<                                 "line": 1064,
+---
+>                                 "line": 1068,
+44056c40032
+<                                 "line": 1064,
+---
+>                                 "line": 1068,
+44060c40036
+<                                 "line": 1064,
+---
+>                                 "line": 1068,
+44081c40057
+<                                 "line": 1065,
+---
+>                                 "line": 1069,
+44085c40061
+<                                 "line": 1065,
+---
+>                                 "line": 1069,
+44096c40072
+<                                 "line": 1065,
+---
+>                                 "line": 1069,
+44100c40076
+<                                 "line": 1065,
+---
+>                                 "line": 1069,
+44121c40097
+<                                 "line": 1066,
+---
+>                                 "line": 1070,
+44125c40101
+<                                 "line": 1066,
+---
+>                                 "line": 1070,
+44136c40112
+<                                 "line": 1066,
+---
+>                                 "line": 1070,
+44140c40116
+<                                 "line": 1066,
+---
+>                                 "line": 1070,
+44161c40137
+<                                 "line": 1067,
+---
+>                                 "line": 1071,
+44165c40141
+<                                 "line": 1067,
+---
+>                                 "line": 1071,
+44176c40152
+<                                 "line": 1067,
+---
+>                                 "line": 1071,
+44180c40156
+<                                 "line": 1067,
+---
+>                                 "line": 1071,
+44300c40276
+<                                 "line": 1080,
+---
+>                                 "line": 1084,
+44304c40280
+<                                 "line": 1080,
+---
+>                                 "line": 1084,
+44325c40301
+<                                 "line": 1082,
+---
+>                                 "line": 1086,
+44329c40305
+<                                 "line": 1082,
+---
+>                                 "line": 1086,
+44428c40404
+<                                 "line": 1114,
+---
+>                                 "line": 1118,
+44432c40408
+<                                 "line": 1114,
+---
+>                                 "line": 1118,
+44443c40419
+<                                 "line": 1114,
+---
+>                                 "line": 1118,
+44447c40423
+<                                 "line": 1114,
+---
+>                                 "line": 1118,
+44468c40444
+<                                 "line": 1115,
+---
+>                                 "line": 1119,
+44472c40448
+<                                 "line": 1115,
+---
+>                                 "line": 1119,
+44483c40459
+<                                 "line": 1115,
+---
+>                                 "line": 1119,
+44487c40463
+<                                 "line": 1115,
+---
+>                                 "line": 1119,
+44508c40484
+<                                 "line": 1116,
+---
+>                                 "line": 1120,
+44512c40488
+<                                 "line": 1116,
+---
+>                                 "line": 1120,
+44523c40499
+<                                 "line": 1116,
+---
+>                                 "line": 1120,
+44527c40503
+<                                 "line": 1116,
+---
+>                                 "line": 1120,
+44548c40524
+<                                 "line": 1117,
+---
+>                                 "line": 1121,
+44552c40528
+<                                 "line": 1117,
+---
+>                                 "line": 1121,
+44563c40539
+<                                 "line": 1117,
+---
+>                                 "line": 1121,
+44567c40543
+<                                 "line": 1117,
+---
+>                                 "line": 1121,
+44578c40554
+<                                 "line": 1117,
+---
+>                                 "line": 1121,
+44582c40558
+<                                 "line": 1117,
+---
+>                                 "line": 1121,
+44798c40774
+<                                 "line": 1152,
+---
+>                                 "line": 1156,
+44802c40778
+<                                 "line": 1152,
+---
+>                                 "line": 1156,
+44823c40799
+<                                 "line": 1153,
+---
+>                                 "line": 1157,
+44827c40803
+<                                 "line": 1153,
+---
+>                                 "line": 1157,
+44944c40920
+<                                 "line": 1169,
+---
+>                                 "line": 1173,
+44948c40924
+<                                 "line": 1169,
+---
+>                                 "line": 1173,
+44969c40945
+<                                 "line": 1170,
+---
+>                                 "line": 1174,
+44973c40949
+<                                 "line": 1170,
+---
+>                                 "line": 1174,
+44994c40970
+<                                 "line": 1171,
+---
+>                                 "line": 1175,
+44998c40974
+<                                 "line": 1171,
+---
+>                                 "line": 1175,
+45019c40995
+<                                 "line": 1172,
+---
+>                                 "line": 1176,
+45023c40999
+<                                 "line": 1172,
+---
+>                                 "line": 1176,
+45095c41071
+<                                 "line": 1183,
+---
+>                                 "line": 1187,
+45099c41075
+<                                 "line": 1183,
+---
+>                                 "line": 1187,
+45120c41096
+<                                 "line": 1184,
+---
+>                                 "line": 1188,
+45124c41100
+<                                 "line": 1184,
+---
+>                                 "line": 1188,
+45178c41154
+<                                 "line": 1187,
+---
+>                                 "line": 1191,
+45182c41158
+<                                 "line": 1187,
+---
+>                                 "line": 1191,
+45236c41212
+<                                 "line": 1190,
+---
+>                                 "line": 1194,
+45240c41216
+<                                 "line": 1190,
+---
+>                                 "line": 1194,
+46126c42102
+<                                 "line": 1617,
+---
+>                                 "line": 1621,
+46130c42106
+<                                 "line": 1617,
+---
+>                                 "line": 1621,
+46151c42127
+<                                 "line": 1618,
+---
+>                                 "line": 1622,
+46155c42131
+<                                 "line": 1618,
+---
+>                                 "line": 1622,
+46176c42152
+<                                 "line": 1619,
+---
+>                                 "line": 1623,
+46180c42156
+<                                 "line": 1619,
+---
+>                                 "line": 1623,
+46201c42177
+<                                 "line": 1620,
+---
+>                                 "line": 1624,
+46205c42181
+<                                 "line": 1620,
+---
+>                                 "line": 1624,
+46226c42202
+<                                 "line": 1621,
+---
+>                                 "line": 1625,
+46230c42206
+<                                 "line": 1621,
+---
+>                                 "line": 1625,
+46251c42227
+<                                 "line": 1622,
+---
+>                                 "line": 1626,
+46255c42231
+<                                 "line": 1622,
+---
+>                                 "line": 1626,
+46276c42252
+<                                 "line": 1628,
+---
+>                                 "line": 1632,
+46280c42256
+<                                 "line": 1628,
+---
+>                                 "line": 1632,
+46301c42277
+<                                 "line": 1629,
+---
+>                                 "line": 1633,
+46305c42281
+<                                 "line": 1629,
+---
+>                                 "line": 1633,
+46326c42302
+<                                 "line": 1630,
+---
+>                                 "line": 1634,
+46330c42306
+<                                 "line": 1630,
+---
+>                                 "line": 1634,
+46393c42369
+<                                 "line": 1638,
+---
+>                                 "line": 1642,
+46397c42373
+<                                 "line": 1638,
+---
+>                                 "line": 1642,
+46418c42394
+<                                 "line": 1639,
+---
+>                                 "line": 1643,
+46422c42398
+<                                 "line": 1639,
+---
+>                                 "line": 1643,
+46443c42419
+<                                 "line": 1640,
+---
+>                                 "line": 1644,
+46447c42423
+<                                 "line": 1640,
+---
+>                                 "line": 1644,
+47852c43828
+<                                 "line": 1973,
+---
+>                                 "line": 1977,
+47856c43832
+<                                 "line": 1973,
+---
+>                                 "line": 1977,
+47877c43853
+<                                 "line": 1975,
+---
+>                                 "line": 1979,
+47881c43857
+<                                 "line": 1975,
+---
+>                                 "line": 1979,
+47902c43878
+<                                 "line": 1976,
+---
+>                                 "line": 1980,
+47906c43882
+<                                 "line": 1976,
+---
+>                                 "line": 1980,
+47927c43903
+<                                 "line": 1977,
+---
+>                                 "line": 1981,
+47931c43907
+<                                 "line": 1977,
+---
+>                                 "line": 1981,
+47952c43928
+<                                 "line": 1978,
+---
+>                                 "line": 1982,
+47956c43932
+<                                 "line": 1978,
+---
+>                                 "line": 1982,
+47977c43953
+<                                 "line": 1979,
+---
+>                                 "line": 1983,
+47981c43957
+<                                 "line": 1979,
+---
+>                                 "line": 1983,
+48173c44149
+<                                 "line": 2077,
+---
+>                                 "line": 2081,
+48177c44153
+<                                 "line": 2077,
+---
+>                                 "line": 2081,
+48198c44174
+<                                 "line": 2078,
+---
+>                                 "line": 2082,
+48202c44178
+<                                 "line": 2078,
+---
+>                                 "line": 2082,
+48223c44199
+<                                 "line": 2079,
+---
+>                                 "line": 2083,
+48227c44203
+<                                 "line": 2079,
+---
+>                                 "line": 2083,
+48245a44222,44236
+>                     }
+>                 ]
+>             },
+>             {
+>                 "category": "class",
+>                 "name": "torch._C.StorageBase",
+>                 "referenceCount": 1,
+>                 "isExported": false,
+>                 "isTypeKnown": true,
+>                 "isTypeAmbiguous": false,
+>                 "diagnostics": [
+>                     {
+>                         "file": "",
+>                         "severity": "warning",
+>                         "message": "No docstring found for class \"torch._C.StorageBase\""
+48246a44238,44240
+>                 ],
+>                 "alternateNames": [
+>                     "torch.StorageBase"
+48691c44685
+<                                 "line": 12612,
+---
+>                                 "line": 12616,
+48695c44689
+<                                 "line": 12612,
+---
+>                                 "line": 12616,
+48716c44710
+<                                 "line": 12613,
+---
+>                                 "line": 12617,
+48720c44714
+<                                 "line": 12613,
+---
+>                                 "line": 12617,
+48741c44735
+<                                 "line": 12614,
+---
+>                                 "line": 12618,
+48745c44739
+<                                 "line": 12614,
+---
+>                                 "line": 12618,
+48766c44760
+<                                 "line": 12615,
+---
+>                                 "line": 12619,
+48770c44764
+<                                 "line": 12615,
+---
+>                                 "line": 12619,
+48781c44775
+<                                 "line": 12615,
+---
+>                                 "line": 12619,
+48785c44779
+<                                 "line": 12615,
+---
+>                                 "line": 12619,
+48806c44800
+<                                 "line": 12616,
+---
+>                                 "line": 12620,
+48810c44804
+<                                 "line": 12616,
+---
+>                                 "line": 12620,
+48821c44815
+<                                 "line": 12616,
+---
+>                                 "line": 12620,
+48825c44819
+<                                 "line": 12616,
+---
+>                                 "line": 12620,
+48927c44921
+<                                 "line": 12648,
+---
+>                                 "line": 12652,
+48931c44925
+<                                 "line": 12648,
+---
+>                                 "line": 12652,
+48952c44946
+<                                 "line": 12649,
+---
+>                                 "line": 12653,
+48956c44950
+<                                 "line": 12649,
+---
+>                                 "line": 12653,
+48977c44971
+<                                 "line": 12650,
+---
+>                                 "line": 12654,
+48981c44975
+<                                 "line": 12650,
+---
+>                                 "line": 12654,
+49035c45029
+<                                 "line": 12653,
+---
+>                                 "line": 12657,
+49039c45033
+<                                 "line": 12653,
+---
+>                                 "line": 12657,
+49060c45054
+<                                 "line": 12654,
+---
+>                                 "line": 12658,
+49064c45058
+<                                 "line": 12654,
+---
+>                                 "line": 12658,
+49085c45079
+<                                 "line": 12655,
+---
+>                                 "line": 12659,
+49089c45083
+<                                 "line": 12655,
+---
+>                                 "line": 12659,
+49110c45104
+<                                 "line": 12656,
+---
+>                                 "line": 12660,
+49114c45108
+<                                 "line": 12656,
+---
+>                                 "line": 12660,
+49135c45129
+<                                 "line": 12657,
+---
+>                                 "line": 12661,
+49139c45133
+<                                 "line": 12657,
+---
+>                                 "line": 12661,
+49160c45154
+<                                 "line": 12658,
+---
+>                                 "line": 12662,
+49164c45158
+<                                 "line": 12658,
+---
+>                                 "line": 12662,
+49185c45179
+<                                 "line": 12659,
+---
+>                                 "line": 12663,
+49189c45183
+<                                 "line": 12659,
+---
+>                                 "line": 12663,
+49210c45204
+<                                 "line": 12660,
+---
+>                                 "line": 12664,
+49214c45208
+<                                 "line": 12660,
+---
+>                                 "line": 12664,
+49235c45229
+<                                 "line": 12661,
+---
+>                                 "line": 12665,
+49239c45233
+<                                 "line": 12661,
+---
+>                                 "line": 12665,
+49260c45254
+<                                 "line": 12662,
+---
+>                                 "line": 12666,
+49264c45258
+<                                 "line": 12662,
+---
+>                                 "line": 12666,
+49285c45279
+<                                 "line": 12663,
+---
+>                                 "line": 12667,
+49289c45283
+<                                 "line": 12663,
+---
+>                                 "line": 12667,
+49310c45304
+<                                 "line": 12664,
+---
+>                                 "line": 12668,
+49314c45308
+<                                 "line": 12664,
+---
+>                                 "line": 12668,
+49378c45372
+<                                 "line": 12670,
+---
+>                                 "line": 12674,
+49382c45376
+<                                 "line": 12670,
+---
+>                                 "line": 12674,
+49436c45430
+<                                 "line": 12674,
+---
+>                                 "line": 12678,
+49440c45434
+<                                 "line": 12674,
+---
+>                                 "line": 12678,
+49494c45488
+<                                 "line": 12678,
+---
+>                                 "line": 12682,
+49498c45492
+<                                 "line": 12678,
+---
+>                                 "line": 12682,
+49553c45547
+<                                 "line": 12682,
+---
+>                                 "line": 12686,
+49557c45551
+<                                 "line": 12682,
+---
+>                                 "line": 12686,
+49612c45606
+<                                 "line": 12686,
+---
+>                                 "line": 12690,
+49616c45610
+<                                 "line": 12686,
+---
+>                                 "line": 12690,
+49671c45665
+<                                 "line": 12690,
+---
+>                                 "line": 12694,
+49675c45669
+<                                 "line": 12690,
+---
+>                                 "line": 12694,
+49729c45723
+<                                 "line": 12694,
+---
+>                                 "line": 12698,
+49733c45727
+<                                 "line": 12694,
+---
+>                                 "line": 12698,
+49787c45781
+<                                 "line": 12698,
+---
+>                                 "line": 12702,
+49791c45785
+<                                 "line": 12698,
+---
+>                                 "line": 12702,
+49845c45839
+<                                 "line": 12702,
+---
+>                                 "line": 12706,
+49849c45843
+<                                 "line": 12702,
+---
+>                                 "line": 12706,
+49904c45898
+<                                 "line": 12706,
+---
+>                                 "line": 12710,
+49908c45902
+<                                 "line": 12706,
+---
+>                                 "line": 12710,
+49962c45956
+<                                 "line": 12710,
+---
+>                                 "line": 12714,
+49966c45960
+<                                 "line": 12710,
+---
+>                                 "line": 12714,
+50020c46014
+<                                 "line": 12718,
+---
+>                                 "line": 12722,
+50024c46018
+<                                 "line": 12718,
+---
+>                                 "line": 12722,
+50088c46082
+<                                 "line": 12722,
+---
+>                                 "line": 12726,
+50092c46086
+<                                 "line": 12722,
+---
+>                                 "line": 12726,
+50113c46107
+<                                 "line": 12724,
+---
+>                                 "line": 12728,
+50117c46111
+<                                 "line": 12724,
+---
+>                                 "line": 12728,
+50138c46132
+<                                 "line": 12726,
+---
+>                                 "line": 12730,
+50142c46136
+<                                 "line": 12726,
+---
+>                                 "line": 12730,
+50163c46157
+<                                 "line": 12728,
+---
+>                                 "line": 12732,
+50167c46161
+<                                 "line": 12728,
+---
+>                                 "line": 12732,
+50188c46182
+<                                 "line": 12730,
+---
+>                                 "line": 12734,
+50192c46186
+<                                 "line": 12730,
+---
+>                                 "line": 12734,
+50213c46207
+<                                 "line": 12732,
+---
+>                                 "line": 12736,
+50217c46211
+<                                 "line": 12732,
+---
+>                                 "line": 12736,
+50238c46232
+<                                 "line": 12734,
+---
+>                                 "line": 12738,
+50242c46236
+<                                 "line": 12734,
+---
+>                                 "line": 12738,
+50306c46300
+<                                 "line": 12738,
+---
+>                                 "line": 12742,
+50310c46304
+<                                 "line": 12738,
+---
+>                                 "line": 12742,
+50331c46325
+<                                 "line": 12739,
+---
+>                                 "line": 12743,
+50335c46329
+<                                 "line": 12739,
+---
+>                                 "line": 12743,
+50399c46393
+<                                 "line": 12743,
+---
+>                                 "line": 12747,
+50403c46397
+<                                 "line": 12743,
+---
+>                                 "line": 12747,
+50547c46541
+<                                 "line": 12761,
+---
+>                                 "line": 12765,
+50551c46545
+<                                 "line": 12761,
+---
+>                                 "line": 12765,
+50572c46566
+<                                 "line": 12763,
+---
+>                                 "line": 12767,
+50576c46570
+<                                 "line": 12763,
+---
+>                                 "line": 12767,
+50587c46581
+<                                 "line": 12763,
+---
+>                                 "line": 12767,
+50591c46585
+<                                 "line": 12763,
+---
+>                                 "line": 12767,
+50654c46648
+<                                 "line": 12767,
+---
+>                                 "line": 12771,
+50658c46652
+<                                 "line": 12767,
+---
+>                                 "line": 12771,
+50721c46715
+<                                 "line": 12771,
+---
+>                                 "line": 12775,
+50725c46719
+<                                 "line": 12771,
+---
+>                                 "line": 12775,
+50864c46858
+<                                 "line": 12786,
+---
+>                                 "line": 12790,
+50868c46862
+<                                 "line": 12786,
+---
+>                                 "line": 12790,
+50889c46883
+<                                 "line": 12788,
+---
+>                                 "line": 12792,
+50893c46887
+<                                 "line": 12788,
+---
+>                                 "line": 12792,
+50914c46908
+<                                 "line": 12789,
+---
+>                                 "line": 12793,
+50918c46912
+<                                 "line": 12789,
+---
+>                                 "line": 12793,
+50939c46933
+<                                 "line": 12790,
+---
+>                                 "line": 12794,
+50943c46937
+<                                 "line": 12790,
+---
+>                                 "line": 12794,
+50964c46958
+<                                 "line": 12791,
+---
+>                                 "line": 12795,
+50968c46962
+<                                 "line": 12791,
+---
+>                                 "line": 12795,
+50989c46983
+<                                 "line": 12792,
+---
+>                                 "line": 12796,
+50993c46987
+<                                 "line": 12792,
+---
+>                                 "line": 12796,
+51014c47008
+<                                 "line": 12793,
+---
+>                                 "line": 12797,
+51018c47012
+<                                 "line": 12793,
+---
+>                                 "line": 12797,
+51039c47033
+<                                 "line": 12794,
+---
+>                                 "line": 12798,
+51043c47037
+<                                 "line": 12794,
+---
+>                                 "line": 12798,
+51064c47058
+<                                 "line": 12795,
+---
+>                                 "line": 12799,
+51068c47062
+<                                 "line": 12795,
+---
+>                                 "line": 12799,
+51089c47083
+<                                 "line": 12797,
+---
+>                                 "line": 12801,
+51093c47087
+<                                 "line": 12797,
+---
+>                                 "line": 12801,
+51104c47098
+<                                 "line": 12797,
+---
+>                                 "line": 12801,
+51108c47102
+<                                 "line": 12797,
+---
+>                                 "line": 12801,
+51267c47261
+<                                 "line": 12810,
+---
+>                                 "line": 12814,
+51271c47265
+<                                 "line": 12810,
+---
+>                                 "line": 12814,
+51436c47430
+<                                 "line": 933,
+---
+>                                 "line": 977,
+51440c47434
+<                                 "line": 933,
+---
+>                                 "line": 977,
+51451c47445
+<                                 "line": 933,
+---
+>                                 "line": 977,
+51455c47449
+<                                 "line": 933,
+---
+>                                 "line": 977,
+51476c47470
+<                                 "line": 950,
+---
+>                                 "line": 994,
+51480c47474
+<                                 "line": 950,
+---
+>                                 "line": 994,
+51491c47485
+<                                 "line": 950,
+---
+>                                 "line": 994,
+51495c47489
+<                                 "line": 950,
+---
+>                                 "line": 994,
+51516c47510
+<                                 "line": 965,
+---
+>                                 "line": 1009,
+51520c47514
+<                                 "line": 965,
+---
+>                                 "line": 1009,
+51531c47525
+<                                 "line": 965,
+---
+>                                 "line": 1009,
+51535c47529
+<                                 "line": 965,
+---
+>                                 "line": 1009,
+51556c47550
+<                                 "line": 980,
+---
+>                                 "line": 1024,
+51560c47554
+<                                 "line": 980,
+---
+>                                 "line": 1024,
+51571c47565
+<                                 "line": 980,
+---
+>                                 "line": 1024,
+51575c47569
+<                                 "line": 980,
+---
+>                                 "line": 1024,
+51586c47580
+<                                 "line": 980,
+---
+>                                 "line": 1024,
+51590c47584
+<                                 "line": 980,
+---
+>                                 "line": 1024,
+51611c47605
+<                                 "line": 1025,
+---
+>                                 "line": 1069,
+51615c47609
+<                                 "line": 1025,
+---
+>                                 "line": 1069,
+51626c47620
+<                                 "line": 1025,
+---
+>                                 "line": 1069,
+51630c47624
+<                                 "line": 1025,
+---
+>                                 "line": 1069,
+51641c47635
+<                                 "line": 1025,
+---
+>                                 "line": 1069,
+51645c47639
+<                                 "line": 1025,
+---
+>                                 "line": 1069,
+51666c47660
+<                                 "line": 1044,
+---
+>                                 "line": 1088,
+51670c47664
+<                                 "line": 1044,
+---
+>                                 "line": 1088,
+51681c47675
+<                                 "line": 1044,
+---
+>                                 "line": 1088,
+51685c47679
+<                                 "line": 1044,
+---
+>                                 "line": 1088,
+51706c47700
+<                                 "line": 1103,
+---
+>                                 "line": 1147,
+51710c47704
+<                                 "line": 1103,
+---
+>                                 "line": 1147,
+51731c47725
+<                                 "line": 1107,
+---
+>                                 "line": 1151,
+51735c47729
+<                                 "line": 1107,
+---
+>                                 "line": 1151,
+51746c47740
+<                                 "line": 1107,
+---
+>                                 "line": 1151,
+51750c47744
+<                                 "line": 1107,
+---
+>                                 "line": 1151,
+51761c47755
+<                                 "line": 1107,
+---
+>                                 "line": 1151,
+51765c47759
+<                                 "line": 1107,
+---
+>                                 "line": 1151,
+51776c47770
+<                                 "line": 1107,
+---
+>                                 "line": 1151,
+51780c47774
+<                                 "line": 1107,
+---
+>                                 "line": 1151,
+51801c47795
+<                                 "line": 1118,
+---
+>                                 "line": 1162,
+51805c47799
+<                                 "line": 1118,
+---
+>                                 "line": 1162,
+51816c47810
+<                                 "line": 1118,
+---
+>                                 "line": 1162,
+51820c47814
+<                                 "line": 1118,
+---
+>                                 "line": 1162,
+51831c47825
+<                                 "line": 1118,
+---
+>                                 "line": 1162,
+51835c47829
+<                                 "line": 1118,
+---
+>                                 "line": 1162,
+51901c47895
+<                                 "line": 1366,
+---
+>                                 "line": 1410,
+51905c47899
+<                                 "line": 1366,
+---
+>                                 "line": 1410,
+52072c48066
+<                 "category": "class",
+---
+>                 "category": "symbol",
+52076c48070
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+52078,52084c48072
+<                 "diagnostics": [
+<                     {
+<                         "file": "",
+<                         "severity": "warning",
+<                         "message": "No docstring found for class \"torch.TypedStorage\""
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+52087c48075
+<                 "category": "class",
+---
+>                 "category": "symbol",
+52091c48079
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+52093,52099c48081
+<                 "diagnostics": [
+<                     {
+<                         "file": "",
+<                         "severity": "warning",
+<                         "message": "No docstring found for class \"torch.UntypedStorage\""
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+52117c48099
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+52122c48104
+<                         "message": "Type of base class \"torch.storage._LegacyStorage\" is partially unknown"
+---
+>                         "message": "Type of base class unknown"
+52140c48122
+<                                 "line": 1984,
+---
+>                                 "line": 2028,
+52144c48126
+<                                 "line": 1984,
+---
+>                                 "line": 2028,
+52269,52332d48250
+<             },
+<             {
+<                 "category": "class",
+<                 "name": "torch.storage._LegacyStorageMeta",
+<                 "referenceCount": 31,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "",
+<                         "severity": "warning",
+<                         "message": "No docstring found for class \"torch.storage._LegacyStorageMeta\""
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "variable",
+<                 "name": "torch.storage._LegacyStorageMeta.dtype",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": []
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.storage._LegacyStorageMeta.__instancecheck__",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"instance\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1514,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1514,
+<                                 "character": 25
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/storage.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1514,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1514,
+<                                 "character": 25
+<                             }
+<                         }
+<                     }
+<                 ]
+52336,52360d48253
+<                 "name": "torch.storage._LegacyStorage",
+<                 "referenceCount": 18,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "",
+<                         "severity": "warning",
+<                         "message": "No docstring found for class \"torch.storage._LegacyStorage\""
+<                     },
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+<                     },
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Type of base class \"torch.storage.TypedStorage\" is partially unknown"
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "class",
+52375c48268
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+52380c48273
+<                         "message": "Type of base class \"torch.storage._LegacyStorage\" is partially unknown"
+---
+>                         "message": "Type of base class unknown"
+52398c48291
+<                                 "line": 1995,
+---
+>                                 "line": 2039,
+52402c48295
+<                                 "line": 1995,
+---
+>                                 "line": 2039,
+52425c48318
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+52430c48323
+<                         "message": "Type of base class \"torch.storage._LegacyStorage\" is partially unknown"
+---
+>                         "message": "Type of base class unknown"
+52448c48341
+<                                 "line": 2006,
+---
+>                                 "line": 2050,
+52452c48345
+<                                 "line": 2006,
+---
+>                                 "line": 2050,
+52475c48368
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+52480c48373
+<                         "message": "Type of base class \"torch.storage._LegacyStorage\" is partially unknown"
+---
+>                         "message": "Type of base class unknown"
+52498c48391
+<                                 "line": 2017,
+---
+>                                 "line": 2061,
+52502c48395
+<                                 "line": 2017,
+---
+>                                 "line": 2061,
+52525c48418
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+52530c48423
+<                         "message": "Type of base class \"torch.storage._LegacyStorage\" is partially unknown"
+---
+>                         "message": "Type of base class unknown"
+52548c48441
+<                                 "line": 2028,
+---
+>                                 "line": 2072,
+52552c48445
+<                                 "line": 2028,
+---
+>                                 "line": 2072,
+52575c48468
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+52580c48473
+<                         "message": "Type of base class \"torch.storage._LegacyStorage\" is partially unknown"
+---
+>                         "message": "Type of base class unknown"
+52598c48491
+<                                 "line": 2039,
+---
+>                                 "line": 2083,
+52602c48495
+<                                 "line": 2039,
+---
+>                                 "line": 2083,
+52625c48518
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+52630c48523
+<                         "message": "Type of base class \"torch.storage._LegacyStorage\" is partially unknown"
+---
+>                         "message": "Type of base class unknown"
+52648c48541
+<                                 "line": 2050,
+---
+>                                 "line": 2094,
+52652c48545
+<                                 "line": 2050,
+---
+>                                 "line": 2094,
+52675c48568
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+52680c48573
+<                         "message": "Type of base class \"torch.storage._LegacyStorage\" is partially unknown"
+---
+>                         "message": "Type of base class unknown"
+52698c48591
+<                                 "line": 2061,
+---
+>                                 "line": 2105,
+52702c48595
+<                                 "line": 2061,
+---
+>                                 "line": 2105,
+52725c48618
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+52730c48623
+<                         "message": "Type of base class \"torch.storage._LegacyStorage\" is partially unknown"
+---
+>                         "message": "Type of base class unknown"
+52748c48641
+<                                 "line": 2072,
+---
+>                                 "line": 2116,
+52752c48645
+<                                 "line": 2072,
+---
+>                                 "line": 2116,
+52775c48668
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+52780c48673
+<                         "message": "Type of base class \"torch.storage._LegacyStorage\" is partially unknown"
+---
+>                         "message": "Type of base class unknown"
+52798c48691
+<                                 "line": 2083,
+---
+>                                 "line": 2127,
+52802c48695
+<                                 "line": 2083,
+---
+>                                 "line": 2127,
+52825c48718
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+52830c48723
+<                         "message": "Type of base class \"torch.storage._LegacyStorage\" is partially unknown"
+---
+>                         "message": "Type of base class unknown"
+52848c48741
+<                                 "line": 2094,
+---
+>                                 "line": 2138,
+52852c48745
+<                                 "line": 2094,
+---
+>                                 "line": 2138,
+52875c48768
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+52880c48773
+<                         "message": "Type of base class \"torch.storage._LegacyStorage\" is partially unknown"
+---
+>                         "message": "Type of base class unknown"
+52898c48791
+<                                 "line": 2105,
+---
+>                                 "line": 2149,
+52902c48795
+<                                 "line": 2105,
+---
+>                                 "line": 2149,
+52925c48818
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+52930c48823
+<                         "message": "Type of base class \"torch.storage._LegacyStorage\" is partially unknown"
+---
+>                         "message": "Type of base class unknown"
+52948c48841
+<                                 "line": 2116,
+---
+>                                 "line": 2160,
+52952c48845
+<                                 "line": 2116,
+---
+>                                 "line": 2160,
+52975c48868
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+52980c48873
+<                         "message": "Type of base class \"torch.storage._LegacyStorage\" is partially unknown"
+---
+>                         "message": "Type of base class unknown"
+52998c48891
+<                                 "line": 2127,
+---
+>                                 "line": 2171,
+53002c48895
+<                                 "line": 2127,
+---
+>                                 "line": 2171,
+53025c48918
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+53030c48923
+<                         "message": "Type of base class \"torch.storage._LegacyStorage\" is partially unknown"
+---
+>                         "message": "Type of base class unknown"
+53048c48941
+<                                 "line": 2138,
+---
+>                                 "line": 2182,
+53052c48945
+<                                 "line": 2138,
+---
+>                                 "line": 2182,
+53075c48968
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+53080c48973
+<                         "message": "Type of base class \"torch.storage._LegacyStorage\" is partially unknown"
+---
+>                         "message": "Type of base class unknown"
+53098c48991
+<                                 "line": 2149,
+---
+>                                 "line": 2193,
+53102c48995
+<                                 "line": 2149,
+---
+>                                 "line": 2193,
+53125c49018
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+53130c49023
+<                         "message": "Type of base class \"torch.storage._LegacyStorage\" is partially unknown"
+---
+>                         "message": "Type of base class unknown"
+53148c49041
+<                                 "line": 2160,
+---
+>                                 "line": 2204,
+53152c49045
+<                                 "line": 2160,
+---
+>                                 "line": 2204,
+53200c49093
+<                                 "line": 2196,
+---
+>                                 "line": 2240,
+53204c49097
+<                                 "line": 2196,
+---
+>                                 "line": 2240,
+53215c49108
+<                                 "line": 2196,
+---
+>                                 "line": 2240,
+53219c49112
+<                                 "line": 2196,
+---
+>                                 "line": 2240,
+53230c49123
+<                                 "line": 2196,
+---
+>                                 "line": 2240,
+53234c49127
+<                                 "line": 2196,
+---
+>                                 "line": 2240,
+53245c49138
+<                                 "line": 2196,
+---
+>                                 "line": 2240,
+53249c49142
+<                                 "line": 2196,
+---
+>                                 "line": 2240,
+53260c49153
+<                                 "line": 2196,
+---
+>                                 "line": 2240,
+53264c49157
+<                                 "line": 2196,
+---
+>                                 "line": 2240,
+53275c49168
+<                                 "line": 2196,
+---
+>                                 "line": 2240,
+53279c49172
+<                                 "line": 2196,
+---
+>                                 "line": 2240,
+53290c49183
+<                                 "line": 2196,
+---
+>                                 "line": 2240,
+53294c49187
+<                                 "line": 2196,
+---
+>                                 "line": 2240,
+53671c49564
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+53673,53689c49566
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/amp/grad_scaler.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 287,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 287,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+53696c49573
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+53787c49664
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+53789,53805c49666
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/optimizer.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 555,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 555,
+<                                 "character": 30
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+53812c49673
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+53814,53830c49675
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/optimizer.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 578,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 578,
+<                                 "character": 31
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+53837c49682
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+53839,53855c49684
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/optimizer.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 599,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 599,
+<                                 "character": 36
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+53862c49691
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+53864,53880c49693
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/optimizer.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 631,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 631,
+<                                 "character": 37
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+53896c49709
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+53898,53914c49711
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/optimizer.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 789,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 789,
+<                                 "character": 41
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+53921c49718
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+53923,53939c49720
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/optimizer.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 828,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 828,
+<                                 "character": 42
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+54009c49790
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+54011,54027c49792
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/amp/grad_scaler.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 359,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 359,
+<                                 "character": 12
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+54176c49941
+<                                 "line": 2198,
+---
+>                                 "line": 2242,
+54180c49945
+<                                 "line": 2198,
+---
+>                                 "line": 2242,
+54210c49975
+<                                 "line": 2198,
+---
+>                                 "line": 2242,
+54214c49979
+<                                 "line": 2198,
+---
+>                                 "line": 2242,
+54225c49990
+<                                 "line": 2198,
+---
+>                                 "line": 2242,
+54229c49994
+<                                 "line": 2198,
+---
+>                                 "line": 2242,
+54259c50024
+<                                 "line": 2198,
+---
+>                                 "line": 2242,
+54263c50028
+<                                 "line": 2198,
+---
+>                                 "line": 2242,
+78266c74031
+<                                 "line": 2387,
+---
+>                                 "line": 2431,
+78270c74035
+<                                 "line": 2387,
+---
+>                                 "line": 2431,
+78430c74195
+<                                 "line": 2402,
+---
+>                                 "line": 2446,
+78434c74199
+<                                 "line": 2402,
+---
+>                                 "line": 2446,
+78455c74220
+<                                 "line": 2413,
+---
+>                                 "line": 2457,
+78459c74224
+<                                 "line": 2413,
+---
+>                                 "line": 2457,
+78470c74235
+<                                 "line": 2413,
+---
+>                                 "line": 2457,
+78474c74239
+<                                 "line": 2413,
+---
+>                                 "line": 2457,
+78485c74250
+<                                 "line": 2413,
+---
+>                                 "line": 2457,
+78489c74254
+<                                 "line": 2413,
+---
+>                                 "line": 2457,
+78500c74265
+<                                 "line": 2413,
+---
+>                                 "line": 2457,
+78504c74269
+<                                 "line": 2413,
+---
+>                                 "line": 2457,
+78525c74290
+<                                 "line": 2419,
+---
+>                                 "line": 2463,
+78529c74294
+<                                 "line": 2419,
+---
+>                                 "line": 2463,
+78550c74315
+<                                 "line": 2420,
+---
+>                                 "line": 2464,
+78554c74319
+<                                 "line": 2420,
+---
+>                                 "line": 2464,
+78584c74349
+<                                 "line": 2596,
+---
+>                                 "line": 2640,
+78588c74353
+<                                 "line": 2596,
+---
+>                                 "line": 2640,
+78599c74364
+<                                 "line": 2596,
+---
+>                                 "line": 2640,
+78603c74368
+<                                 "line": 2596,
+---
+>                                 "line": 2640,
+78660c74425
+<                                 "line": 2793,
+---
+>                                 "line": 2837,
+78664c74429
+<                                 "line": 2793,
+---
+>                                 "line": 2837,
+78675c74440
+<                                 "line": 2793,
+---
+>                                 "line": 2837,
+78679c74444
+<                                 "line": 2793,
+---
+>                                 "line": 2837,
+78700c74465
+<                                 "line": 2793,
+---
+>                                 "line": 2837,
+78704c74469
+<                                 "line": 2793,
+---
+>                                 "line": 2837,
+78715c74480
+<                                 "line": 2793,
+---
+>                                 "line": 2837,
+78719c74484
+<                                 "line": 2793,
+---
+>                                 "line": 2837,
+78730c74495
+<                                 "line": 2793,
+---
+>                                 "line": 2837,
+78734c74499
+<                                 "line": 2793,
+---
+>                                 "line": 2837,
+78745c74510
+<                                 "line": 2793,
+---
+>                                 "line": 2837,
+78749c74514
+<                                 "line": 2793,
+---
+>                                 "line": 2837,
+78770c74535
+<                                 "line": 2794,
+---
+>                                 "line": 2838,
+78774c74539
+<                                 "line": 2794,
+---
+>                                 "line": 2838,
+78785c74550
+<                                 "line": 2794,
+---
+>                                 "line": 2838,
+78789c74554
+<                                 "line": 2794,
+---
+>                                 "line": 2838,
+79013c74778
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+79015,79031c74780
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/accelerator/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"Stream\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 184,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 184,
+<                                 "character": 18
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+79038c74787
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+79040,79056c74789
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/accelerator/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"stream\" is partially unknown\n  Parameter type is \"Stream\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 199,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 199,
+<                                 "character": 14
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+80148c75881
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+80150,80166c75883
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/nn/modules/module.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1372,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1372,
+<                                 "character": 39
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+80173c75890
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+80175,80191c75892
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/nn/modules/module.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1421,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1421,
+<                                 "character": 30
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+80198c75899
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+80200,80216c75901
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/nn/modules/module.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1447,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1447,
+<                                 "character": 35
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+80223c75908
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+80225,80241c75910
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/nn/modules/module.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1611,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1611,
+<                                 "character": 33
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+80248c75917
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+80250,80266c75919
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/nn/modules/module.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1677,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1677,
+<                                 "character": 29
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+133655c129308
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+133657,133673c129310
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/package/package_exporter.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 734,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 734,
+<                                 "character": 28
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+133680c129317
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+133682,133698c129319
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/package/package_exporter.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 753,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 753,
+<                                 "character": 26
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+133705c129326
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+133707,133723c129328
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/package/package_exporter.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 772,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 772,
+<                                 "character": 28
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+169920c165525
+<                                 "line": 306,
+---
+>                                 "line": 310,
+169924c165529
+<                                 "line": 306,
+---
+>                                 "line": 310,
+169935c165540
+<                                 "line": 306,
+---
+>                                 "line": 310,
+169939c165544
+<                                 "line": 306,
+---
+>                                 "line": 310,
+170980c166585
+<                                 "line": 313,
+---
+>                                 "line": 317,
+170984c166589
+<                                 "line": 313,
+---
+>                                 "line": 317,
+170995c166600
+<                                 "line": 313,
+---
+>                                 "line": 317,
+170999c166604
+<                                 "line": 313,
+---
+>                                 "line": 317,
+171010c166615
+<                                 "line": 313,
+---
+>                                 "line": 317,
+171014c166619
+<                                 "line": 313,
+---
+>                                 "line": 317,
+171096c166701
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+171105c166710
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+171123c166728
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+172902,172916d168506
+<                         "range": {
+<                             "start": {
+<                                 "line": 201,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 201,
+<                                 "character": 21
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/autograd/graph.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"GradientEdge\"",
+173041c168631
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+173043,173059c168633
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/autograd/graph.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 449,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 449,
+<                                 "character": 28
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+180789c176363
+<                                 "line": 12366,
+---
+>                                 "line": 12370,
+180793c176367
+<                                 "line": 12366,
+---
+>                                 "line": 12370,
+180804c176378
+<                                 "line": 12366,
+---
+>                                 "line": 12370,
+180808c176382
+<                                 "line": 12366,
+---
+>                                 "line": 12370,
+180819c176393
+<                                 "line": 12366,
+---
+>                                 "line": 12370,
+180823c176397
+<                                 "line": 12366,
+---
+>                                 "line": 12370,
+180834c176408
+<                                 "line": 12366,
+---
+>                                 "line": 12370,
+180838c176412
+<                                 "line": 12366,
+---
+>                                 "line": 12370,
+186930c182504
+<                                 "line": 12470,
+---
+>                                 "line": 12474,
+186934c182508
+<                                 "line": 12470,
+---
+>                                 "line": 12474,
+186955c182529
+<                                 "line": 12471,
+---
+>                                 "line": 12475,
+186959c182533
+<                                 "line": 12471,
+---
+>                                 "line": 12475,
+186970c182544
+<                                 "line": 12471,
+---
+>                                 "line": 12475,
+186974c182548
+<                                 "line": 12471,
+---
+>                                 "line": 12475,
+186995c182569
+<                                 "line": 12476,
+---
+>                                 "line": 12480,
+186999c182573
+<                                 "line": 12476,
+---
+>                                 "line": 12480,
+187020c182594
+<                                 "line": 12477,
+---
+>                                 "line": 12481,
+187024c182598
+<                                 "line": 12477,
+---
+>                                 "line": 12481,
+187045c182619
+<                                 "line": 12478,
+---
+>                                 "line": 12482,
+187049c182623
+<                                 "line": 12478,
+---
+>                                 "line": 12482,
+187060c182634
+<                                 "line": 12478,
+---
+>                                 "line": 12482,
+187064c182638
+<                                 "line": 12478,
+---
+>                                 "line": 12482,
+187085c182659
+<                                 "line": 12479,
+---
+>                                 "line": 12483,
+187089c182663
+<                                 "line": 12479,
+---
+>                                 "line": 12483,
+187110c182684
+<                                 "line": 12480,
+---
+>                                 "line": 12484,
+187114c182688
+<                                 "line": 12480,
+---
+>                                 "line": 12484,
+187135c182709
+<                                 "line": 12481,
+---
+>                                 "line": 12485,
+187139c182713
+<                                 "line": 12481,
+---
+>                                 "line": 12485,
+187160c182734
+<                                 "line": 12482,
+---
+>                                 "line": 12486,
+187164c182738
+<                                 "line": 12482,
+---
+>                                 "line": 12486,
+187185c182759
+<                                 "line": 12483,
+---
+>                                 "line": 12487,
+187189c182763
+<                                 "line": 12483,
+---
+>                                 "line": 12487,
+187210c182784
+<                                 "line": 12484,
+---
+>                                 "line": 12488,
+187214c182788
+<                                 "line": 12484,
+---
+>                                 "line": 12488,
+187258,187264c182832
+<                 "diagnostics": [
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Type of base class \"torch._C._CudaStreamBase\" is partially unknown"
+<                     }
+<                 ],
+---
+>                 "diagnostics": [],
+187527c183095
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+187534,187538d183101
+<                     },
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Type of base class \"torch._C.Stream\" is partially unknown"
+187619c183182
+<                                 "line": 12443,
+---
+>                                 "line": 12447,
+187623c183186
+<                                 "line": 12443,
+---
+>                                 "line": 12447,
+187644c183207
+<                                 "line": 12444,
+---
+>                                 "line": 12448,
+187648c183211
+<                                 "line": 12444,
+---
+>                                 "line": 12448,
+187669c183232
+<                                 "line": 12445,
+---
+>                                 "line": 12449,
+187673c183236
+<                                 "line": 12445,
+---
+>                                 "line": 12449,
+188043,188049c183606
+<                 "diagnostics": [
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Type of base class \"torch._C._CudaEventBase\" is partially unknown"
+<                     }
+<                 ],
+---
+>                 "diagnostics": [],
+188372c183929
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+188423c183980
+<                                 "line": 12460,
+---
+>                                 "line": 12464,
+188427c183984
+<                                 "line": 12460,
+---
+>                                 "line": 12464,
+188439c183996
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+188446,188460d184002
+<                         "range": {
+<                             "start": {
+<                                 "line": 12461,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 12461,
+<                                 "character": 14
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"stream\" is partially unknown\n  Parameter type is \"_CudaStreamBase\"",
+188463c184005
+<                                 "line": 12461,
+---
+>                                 "line": 12465,
+188467c184009
+<                                 "line": 12461,
+---
+>                                 "line": 12465,
+188479c184021
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+188488c184030
+<                                 "line": 12462,
+---
+>                                 "line": 12466,
+188492c184034
+<                                 "line": 12462,
+---
+>                                 "line": 12466,
+188496,188510d184037
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"stream\" is partially unknown\n  Parameter type is \"_CudaStreamBase\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 12462,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 12462,
+<                                 "character": 12
+<                             }
+<                         }
+188528c184055
+<                                 "line": 12463,
+---
+>                                 "line": 12467,
+188532c184059
+<                                 "line": 12463,
+---
+>                                 "line": 12467,
+188553c184080
+<                                 "line": 12464,
+---
+>                                 "line": 12468,
+188557c184084
+<                                 "line": 12464,
+---
+>                                 "line": 12468,
+188578c184105
+<                                 "line": 12465,
+---
+>                                 "line": 12469,
+188582c184109
+<                                 "line": 12465,
+---
+>                                 "line": 12469,
+188603c184130
+<                                 "line": 12466,
+---
+>                                 "line": 12470,
+188607c184134
+<                                 "line": 12466,
+---
+>                                 "line": 12470,
+190138c185665
+<                                 "line": 12501,
+---
+>                                 "line": 12505,
+190142c185669
+<                                 "line": 12501,
+---
+>                                 "line": 12505,
+190276c185803
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+190326c185853
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+190331c185858
+<                         "message": "Type of base class \"torch.storage._LegacyStorage\" is partially unknown"
+---
+>                         "message": "Type of base class unknown"
+190421c185948
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+190471c185998
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+190521c186048
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+190571c186098
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+190621c186148
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+190671c186198
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+190721c186248
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+190771c186298
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+190821c186348
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+190871c186398
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+190921c186448
+<                         "message": "Type of metaclass \"_LegacyStorageMeta\" is partially unknown"
+---
+>                         "message": "Type of metaclass unknown"
+202562,202566d198088
+<                         "message": "Type of base class \"torch.optim.optimizer.Optimizer\" is partially unknown"
+<                     },
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+202651c198173
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+202668,202682d198189
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/distributed/optim/zero_redundancy_optimizer.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizer_class\" is partially unknown\n  Parameter type is \"type[Optimizer]\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 55,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 55,
+<                                 "character": 16
+<                             }
+<                         }
+215018,215032d210524
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/distributed/checkpoint/state_dict.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizers\" is partially unknown\n  Parameter type is \"Optimizer | Iterable[Optimizer]\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1065,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1065,
+<                                 "character": 28
+<                             }
+<                         }
+215058,215072d210549
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/distributed/checkpoint/state_dict.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizers\" is partially unknown\n  Parameter type is \"Optimizer | Iterable[Optimizer]\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1110,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1110,
+<                                 "character": 18
+<                             }
+<                         }
+215267,215281d210743
+<                         "range": {
+<                             "start": {
+<                                 "line": 1273,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1273,
+<                                 "character": 28
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/distributed/checkpoint/state_dict.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizers\" is partially unknown\n  Parameter type is \"Optimizer | Iterable[Optimizer]\"",
+215307,215321d210768
+<                         "range": {
+<                             "start": {
+<                                 "line": 1316,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1316,
+<                                 "character": 18
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/distributed/checkpoint/state_dict.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizers\" is partially unknown\n  Parameter type is \"Optimizer | Iterable[Optimizer]\"",
+232073,232087d227519
+<                         "range": {
+<                             "start": {
+<                                 "line": 1361,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1361,
+<                                 "character": 29
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optim\" is partially unknown\n  Parameter type is \"Optimizer\"",
+232142,232156d227573
+<                         "message": "Type of parameter \"optim\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1437,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1437,
+<                                 "character": 32
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py",
+<                         "severity": "error",
+232193,232207d227609
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optim\" is partially unknown\n  Parameter type is \"Optimizer | None\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1471,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1471,
+<                                 "character": 35
+<                             }
+<                         }
+232233,232247d227634
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optim\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1550,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1550,
+<                                 "character": 40
+<                             }
+<                         }
+232263,232277d227649
+<                         "range": {
+<                             "start": {
+<                                 "line": 1589,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1589,
+<                                 "character": 37
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optim\" is partially unknown\n  Parameter type is \"Optimizer | None\"",
+232313,232327d227684
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optim\" is partially unknown\n  Parameter type is \"Optimizer | None\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1673,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1673,
+<                                 "character": 30
+<                             }
+<                         }
+232387,232401d227743
+<                         "message": "Type of parameter \"optim\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1798,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1798,
+<                                 "character": 24
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py",
+<                         "severity": "error",
+232428,232442d227769
+<                         "range": {
+<                             "start": {
+<                                 "line": 1894,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1894,
+<                                 "character": 32
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optim\" is partially unknown\n  Parameter type is \"Optimizer\"",
+233186c228513
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+233203,233217d228529
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/distributed/fsdp/sharded_grad_scaler.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 224,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 224,
+<                                 "character": 16
+<                             }
+<                         }
+235332c230644
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+235349,235363d230660
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/distributed/nn/api/remote_module.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 355,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 355,
+<                                 "character": 30
+<                             }
+<                         }
+235372c230669
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+235379,235393d230675
+<                         "range": {
+<                             "start": {
+<                                 "line": 360,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 360,
+<                                 "character": 33
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/distributed/nn/api/remote_module.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+235412c230694
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+235419,235433d230700
+<                         "range": {
+<                             "start": {
+<                                 "line": 374,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 374,
+<                                 "character": 29
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/distributed/nn/api/remote_module.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+237437,237443c232704
+<                 "diagnostics": [
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Type of base class \"torch.optim.optimizer.Optimizer\" is partially unknown"
+<                     }
+<                 ],
+---
+>                 "diagnostics": [],
+237459,237473d232719
+<                         "message": "Type of parameter \"optim\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 57,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 57,
+<                                 "character": 16
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/distributed/optim/post_localSGD_optimizer.py",
+<                         "severity": "error",
+237718c232964
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+304219c299465
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+304228c299474
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+304294c299540
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+305119c300365
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+305126,305140d300371
+<                         "range": {
+<                             "start": {
+<                                 "line": 812,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 812,
+<                                 "character": 24
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_subclasses/meta_utils.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"s\" is partially unknown\n  Parameter type is \"MetaStorageDesc\"",
+305151,305165d300381
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_subclasses/meta_utils.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"UntypedStorage | None\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 812,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 812,
+<                                 "character": 24
+<                             }
+<                         }
+305174c300390
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+305181,305195d300396
+<                         "range": {
+<                             "start": {
+<                                 "line": 815,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 815,
+<                                 "character": 24
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_subclasses/meta_utils.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"s\" is partially unknown\n  Parameter type is \"MetaStorageDesc\"",
+305206,305220d300406
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_subclasses/meta_utils.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"v\" is partially unknown\n  Parameter type is \"UntypedStorage\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 815,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 815,
+<                                 "character": 24
+<                             }
+<                         }
+305229c300415
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+305236,305265d300421
+<                         "range": {
+<                             "start": {
+<                                 "line": 818,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 818,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_subclasses/meta_utils.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"s\" is partially unknown\n  Parameter type is \"MetaStorageDesc\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 818,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 818,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_subclasses/meta_utils.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"UntypedStorage\"",
+305613c300769
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+305630,305644d300785
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_subclasses/meta_utils.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"s\" is partially unknown\n  Parameter type is \"UntypedStorage\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 252,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 252,
+<                                 "character": 22
+<                             }
+<                         }
+305653c300794
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+305660,305689d300800
+<                         "range": {
+<                             "start": {
+<                                 "line": 258,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 258,
+<                                 "character": 24
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_subclasses/meta_utils.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"s\" is partially unknown\n  Parameter type is \"UntypedStorage\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 258,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 258,
+<                                 "character": 24
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_subclasses/meta_utils.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"MetaStorageDesc\"",
+392244c387355
+<                                 "line": 1755,
+---
+>                                 "line": 1759,
+392248c387359
+<                                 "line": 1755,
+---
+>                                 "line": 1759,
+392259c387370
+<                                 "line": 1755,
+---
+>                                 "line": 1759,
+392263c387374
+<                                 "line": 1755,
+---
+>                                 "line": 1759,
+392274c387385
+<                                 "line": 1755,
+---
+>                                 "line": 1759,
+392278c387389
+<                                 "line": 1755,
+---
+>                                 "line": 1759,
+392329c387440
+<                                 "line": 1708,
+---
+>                                 "line": 1712,
+392333c387444
+<                                 "line": 1708,
+---
+>                                 "line": 1712,
+392354c387465
+<                                 "line": 1709,
+---
+>                                 "line": 1713,
+392358c387469
+<                                 "line": 1709,
+---
+>                                 "line": 1713,
+392379c387490
+<                                 "line": 1710,
+---
+>                                 "line": 1714,
+392383c387494
+<                                 "line": 1710,
+---
+>                                 "line": 1714,
+392394c387505
+<                                 "line": 1710,
+---
+>                                 "line": 1714,
+392398c387509
+<                                 "line": 1710,
+---
+>                                 "line": 1714,
+392409c387520
+<                                 "line": 1710,
+---
+>                                 "line": 1714,
+392413c387524
+<                                 "line": 1710,
+---
+>                                 "line": 1714,
+399169c394280
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+399297c394408
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+399299,399315c394410
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/mtia/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"Stream\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 150,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 150,
+<                                 "character": 18
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+399322c394417
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+399324,399340c394419
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/mtia/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"Stream\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 162,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 162,
+<                                 "character": 18
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+399435,399449d394513
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/mtia/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"stream\" is partially unknown\n  Parameter type is \"Stream\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 226,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 226,
+<                                 "character": 14
+<                             }
+<                         }
+<                     },
+399617c394681
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+399626c394690
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+399628,399644c394692
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/mtia/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"stream\" is partially unknown\n  Parameter type is \"Stream | None\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 297,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 297,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+399701c394749
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+399735c394783
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+399744c394792
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+399756,399770d394803
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/mtia/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"stream\" is partially unknown\n  Parameter type is \"Stream | None\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 352,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 352,
+<                                 "character": 10
+<                             }
+<                         }
+<                     },
+441050c436083
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+441052,441068c436085
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/nn/modules/module.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 135,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 135,
+<                                 "character": 44
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+441075c436092
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+441077,441093c436094
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/nn/modules/module.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 161,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 161,
+<                                 "character": 44
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+441100c436101
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+441102,441118c436103
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/nn/modules/module.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 187,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 187,
+<                                 "character": 47
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+441125c436110
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+441127,441143c436112
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/nn/modules/module.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 213,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 213,
+<                                 "character": 36
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+441150c436119
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+441152,441168c436121
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/nn/modules/module.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 245,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 245,
+<                                 "character": 32
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+441175c436128
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+441177,441193c436130
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/nn/modules/module.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 292,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 292,
+<                                 "character": 33
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+441200c436137
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+441202,441218c436139
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/nn/modules/module.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 321,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 321,
+<                                 "character": 42
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+441225c436146
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+441227,441243c436148
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/nn/modules/module.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 348,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 348,
+<                                 "character": 38
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+484448,484452d479352
+<                     },
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Type of base class \"torch.optim.optimizer.Optimizer\" is partially unknown"
+484591,484595d479490
+<                     },
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Type of base class \"torch.optim.optimizer.Optimizer\" is partially unknown"
+484703,484707d479597
+<                     },
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Type of base class \"torch.optim.optimizer.Optimizer\" is partially unknown"
+484840,484844d479729
+<                     },
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Type of base class \"torch.optim.optimizer.Optimizer\" is partially unknown"
+484952,484956d479836
+<                     },
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Type of base class \"torch.optim.optimizer.Optimizer\" is partially unknown"
+485167,485171d480046
+<                     },
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Type of base class \"torch.optim.optimizer.Optimizer\" is partially unknown"
+485268,485274c480143
+<                 "diagnostics": [
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Type of base class \"torch.optim.optimizer.Optimizer\" is partially unknown"
+<                     }
+<                 ],
+---
+>                 "diagnostics": [],
+485371,485375d480239
+<                     },
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Type of base class \"torch.optim.optimizer.Optimizer\" is partially unknown"
+485461c480325
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+485492,485496d480355
+<                     },
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Type of base class \"torch.optim.optimizer.Optimizer\" is partially unknown"
+485604,485608d480462
+<                     },
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Type of base class \"torch.optim.optimizer.Optimizer\" is partially unknown"
+485716,485720d480569
+<                     },
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Type of base class \"torch.optim.optimizer.Optimizer\" is partially unknown"
+485828,485832d480676
+<                     },
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Type of base class \"torch.optim.optimizer.Optimizer\" is partially unknown"
+485955,485959d480798
+<                     },
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Type of base class \"torch.optim.optimizer.Optimizer\" is partially unknown"
+486341c481180
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+486343,486359c481182
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/lr_scheduler.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 87,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 87,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+486427c481250
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+486485c481308
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+486487,486503c481310
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/lr_scheduler.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 300,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 300,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+486537c481344
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+486570c481377
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+486572,486588c481379
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/lr_scheduler.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 398,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 398,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+486622c481413
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+486655c481446
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+486657,486673c481448
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/lr_scheduler.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 505,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 505,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+486722c481497
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+486724,486740c481499
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/lr_scheduler.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 560,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 560,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+486805c481564
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+486807,486823c481566
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/lr_scheduler.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 624,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 624,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+486872c481615
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+486874,486890c481617
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/lr_scheduler.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 699,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 699,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+486948c481675
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+486950,486966c481677
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/lr_scheduler.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 782,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 782,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+487006c481717
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+487008,487024c481719
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/lr_scheduler.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 843,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 843,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+487123c481818
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+487147c481842
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+487149,487165c481844
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/lr_scheduler.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 986,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 986,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+487214c481893
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+487216,487232c481895
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/lr_scheduler.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1072,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1072,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+487281c481944
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+487283,487299c481946
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/lr_scheduler.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer | None\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1153,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1153,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+487333c481980
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+487357c482004
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+487359,487375c482006
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/lr_scheduler.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1288,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1288,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+487440c482071
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+487771c482402
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+487773,487789c482404
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/lr_scheduler.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1527,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1527,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+487848c482463
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+488142c482757
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+488144,488160c482759
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/lr_scheduler.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1761,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1761,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+488318c482917
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+488320,488336c482919
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/lr_scheduler.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1974,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1974,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+488352c482935
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+488535c483118
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+488537,488553c483120
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/optimizer.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 289,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 289,
+<                                 "character": 36
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+488560c483127
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+488562,488578c483129
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/optimizer.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"RemovableHandle\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 309,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 309,
+<                                 "character": 37
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+489130,489144d483680
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 417,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 417,
+<                                 "character": 16
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/optim/swa_utils.py",
+<                         "severity": "error",
+492342c486878
+<                 "isTypeAmbiguous": false,
+---
+>                 "isTypeAmbiguous": true,
+495350c489886
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+496203,496217d490738
+<                         "message": "Type of parameter \"storage\" is partially unknown\n  Parameter type is \"Storage | TypedStorage | UntypedStorage\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 664,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 664,
+<                                 "character": 16
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/serialization.py",
+<                         "severity": "error",
+500541,500558d495061
+<                 "category": "constant",
+<                 "name": "torch.storage.HAS_NUMPY",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": []
+<             },
+<             {
+<                 "category": "type variable",
+<                 "name": "torch.storage.T",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": []
+<             },
+<             {
+505799,505813d500301
+<                         "range": {
+<                             "start": {
+<                                 "line": 39,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 39,
+<                                 "character": 18
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/utils/benchmark/utils/compile.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer | None\"",
+505883,505897d500370
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer | None\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 73,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 73,
+<                                 "character": 25
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/utils/benchmark/utils/compile.py",
+<                         "severity": "error",
+505968,505982d500440
+<                         "message": "Type of parameter \"optimizer\" is partially unknown\n  Parameter type is \"Optimizer | None\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 118,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 118,
+<                                 "character": 17
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/utils/benchmark/utils/compile.py",
+<                         "severity": "error",
+536075a530534,530551
+>                 "category": "type alias",
+>                 "name": "torch.utils.hooks.HooksDict",
+>                 "referenceCount": 1,
+>                 "isExported": true,
+>                 "isTypeKnown": true,
+>                 "isTypeAmbiguous": false,
+>                 "diagnostics": []
+>             },
+>             {
+>                 "category": "type alias",
+>                 "name": "torch.utils.hooks.ExtraDict",
+>                 "referenceCount": 1,
+>                 "isExported": true,
+>                 "isTypeKnown": true,
+>                 "isTypeAmbiguous": false,
+>                 "diagnostics": []
+>             },
+>             {
+536089c530565
+<                                 "line": 71,
+---
+>                                 "line": 80,
+536093c530569
+<                                 "line": 71,
+---
+>                                 "line": 80,
+536104c530580
+<                                 "line": 71,
+---
+>                                 "line": 80,
+536108c530584
+<                                 "line": 71,
+---
+>                                 "line": 80,
+536129c530605
+<                                 "line": 82,
+---
+>                                 "line": 91,
+536133c530609
+<                                 "line": 82,
+---
+>                                 "line": 91,
+536144c530620
+<                                 "line": 82,
+---
+>                                 "line": 91,
+536148c530624
+<                                 "line": 82,
+---
+>                                 "line": 91,
+536159c530635
+<                                 "line": 82,
+---
+>                                 "line": 91,
+536163c530639
+<                                 "line": 82,
+---
+>                                 "line": 91,
+536193c530669
+<                                 "line": 103,
+---
+>                                 "line": 112,
+536197c530673
+<                                 "line": 103,
+---
+>                                 "line": 112,
+536208c530684
+<                                 "line": 103,
+---
+>                                 "line": 112,
+536212c530688
+<                                 "line": 103,
+---
+>                                 "line": 112,
+536223c530699
+<                                 "line": 103,
+---
+>                                 "line": 112,
+536227c530703
+<                                 "line": 103,
+---
+>                                 "line": 112,
+536248c530724
+<                                 "line": 190,
+---
+>                                 "line": 199,
+536252c530728
+<                                 "line": 190,
+---
+>                                 "line": 199,
+536263c530739
+<                                 "line": 190,
+---
+>                                 "line": 199,
+536267c530743
+<                                 "line": 190,
+---
+>                                 "line": 199,
+536278c530754
+<                                 "line": 190,
+---
+>                                 "line": 199,
+536282c530758
+<                                 "line": 190,
+---
+>                                 "line": 199,
+536303c530779
+<                                 "line": 199,
+---
+>                                 "line": 208,
+536307c530783
+<                                 "line": 199,
+---
+>                                 "line": 208,
+536318c530794
+<                                 "line": 199,
+---
+>                                 "line": 208,
+536322c530798
+<                                 "line": 199,
+---
+>                                 "line": 208,
+536333c530809
+<                                 "line": 199,
+---
+>                                 "line": 208,
+536337c530813
+<                                 "line": 199,
+---
+>                                 "line": 208,
+536385c530861
+<                                 "line": 108,
+---
+>                                 "line": 117,
+536389c530865
+<                                 "line": 108,
+---
+>                                 "line": 117,
+536410c530886
+<                                 "line": 250,
+---
+>                                 "line": 259,
+536414c530890
+<                                 "line": 250,
+---
+>                                 "line": 259,
+536435c530911
+<                                 "line": 251,
+---
+>                                 "line": 260,
+536439c530915
+<                                 "line": 251,
+---
+>                                 "line": 260,
+536450c530926
+<                                 "line": 251,
+---
+>                                 "line": 260,
+536454c530930
+<                                 "line": 251,
+---
+>                                 "line": 260,
+536475c530951
+<                                 "line": 195,
+---
+>                                 "line": 204,
+536479c530955
+<                                 "line": 195,
+---
+>                                 "line": 204,
+536500c530976
+<                                 "line": 196,
+---
+>                                 "line": 205,
+536504c530980
+<                                 "line": 196,
+---
+>                                 "line": 205,
+536515c530991
+<                                 "line": 196,
+---
+>                                 "line": 205,
+536519c530995
+<                                 "line": 196,
+---
+>                                 "line": 205,
+543264c537740
+<                                 "line": 12577,
+---
+>                                 "line": 12581,
+543268c537744
+<                                 "line": 12577,
+---
+>                                 "line": 12581,
+543289c537765
+<                                 "line": 12578,
+---
+>                                 "line": 12582,
+543293c537769
+<                                 "line": 12578,
+---
+>                                 "line": 12582,
+543304c537780
+<                                 "line": 12578,
+---
+>                                 "line": 12582,
+543308c537784
+<                                 "line": 12578,
+---
+>                                 "line": 12582,
+543327,543331d537802
+<                     },
+<                     {
+<                         "file": "",
+<                         "severity": "error",
+<                         "message": "Type of base class \"torch._C.Stream\" is partially unknown"
+543412c537883
+<                                 "line": 12566,
+---
+>                                 "line": 12570,
+543416c537887
+<                                 "line": 12566,
+---
+>                                 "line": 12570,
+543437c537908
+<                                 "line": 12567,
+---
+>                                 "line": 12571,
+543441c537912
+<                                 "line": 12567,
+---
+>                                 "line": 12571,
+543462c537933
+<                                 "line": 12569,
+---
+>                                 "line": 12573,
+543466c537937
+<                                 "line": 12569,
+---
+>                                 "line": 12573,
+543477c537948
+<                                 "line": 12569,
+---
+>                                 "line": 12573,
+543481c537952
+<                                 "line": 12569,
+---
+>                                 "line": 12573,
+543502c537973
+<                                 "line": 12579,
+---
+>                                 "line": 12583,
+543506c537977
+<                                 "line": 12579,
+---
+>                                 "line": 12583,
+543527c537998
+<                                 "line": 12580,
+---
+>                                 "line": 12584,
+543531c538002
+<                                 "line": 12580,
+---
+>                                 "line": 12584,
+543552c538023
+<                                 "line": 12581,
+---
+>                                 "line": 12585,
+543556c538027
+<                                 "line": 12581,
+---
+>                                 "line": 12585,

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -1263,7 +1263,9 @@ def gen_pyi(
             "new_tensor": [
                 defs("new_tensor", ["self", "data: Any", *FACTORY_PARAMS], "Tensor")
             ],
-            "__new__": [defs("__new__", ["cls", "*args", "**kwargs"], "Self")],
+            "__new__": [
+                defs("__new__", ["cls", "*args: Any", "**kwargs: Any"], "Self")
+            ],
             # new and __init__ have the same signatures differ only in return type
             # Adapted from legacy_tensor_ctor and legacy_tensor_new
             "new": [
@@ -1327,7 +1329,8 @@ def gen_pyi(
                     "None",
                 )
             ],
-            "tolist": [defs("tolist", ["self"], "list")],
+            # TODO: replace list[Any] with NestedList and fix errors
+            "tolist": [defs("tolist", ["self"], "list[Any]")],
             "requires_grad_": [
                 defs("requires_grad_", ["self", "mode: _bool = True"], "Tensor")
             ],
@@ -1384,7 +1387,11 @@ def gen_pyi(
                 )
             ],
             "numpy": [
-                defs("numpy", ["self", "*", "force: _bool = False"], "numpy.ndarray")
+                defs(
+                    "numpy",
+                    ["self", "*", "force: _bool = False"],
+                    "numpy.ndarray[Any, Any]",
+                )
             ],
             "apply_": [defs("apply_", ["self", "callable: Callable"], "Tensor")],
             "map_": [
@@ -1487,7 +1494,7 @@ def gen_pyi(
                     "set_",
                     [
                         "self",
-                        "source: Storage | TypedStorage | UntypedStorage",
+                        "source: Storage | UntypedStorage",
                         "storage_offset: IntLikeType",
                         "size: _symsize",
                         "stride: _symsize",
@@ -1496,7 +1503,7 @@ def gen_pyi(
                 ),
                 defs(
                     "set_",
-                    ["self", "source: Storage | TypedStorage | UntypedStorage"],
+                    ["self", "source: Storage | UntypedStorage"],
                     "Tensor",
                 ),
             ],

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -18,7 +18,9 @@ from typing import (
     NamedTuple,
     overload,
     SupportsIndex,
+    TypeAlias,
     TypeVar,
+    Union,
 )
 from typing_extensions import ParamSpec, Protocol, runtime_checkable, Self, TypeAlias
 
@@ -44,7 +46,7 @@ from torch.autograd.graph import Node as _Node
 from torch.cuda import _POOL_HANDLE
 from torch.fx.node import Node as FxNode
 from torch.package import PackageExporter
-from torch.storage import TypedStorage, UntypedStorage
+from torch.storage import UntypedStorage
 from torch.types import (
     _bool,
     _bytes,
@@ -74,6 +76,8 @@ S = TypeVar("S", bound=torch.Tensor)  # noqa: PYI001
 P = ParamSpec("P")  # noqa: PYI001
 R = TypeVar("R", covariant=True)  # return value (always covariant)  # noqa: PYI001
 T_co = TypeVar("T_co", covariant=True)  # noqa: PYI001
+
+NestedList: TypeAlias = Union[Number, complex, list['NestedList']]
 
 @runtime_checkable
 class _NestedSequence(Protocol[T_co]):
@@ -147,7 +151,7 @@ class Stream:
     def __hash__(self) -> _int: ...
     def __eq__(self, other: object) -> _bool: ...
     def __enter__(self) -> Self: ...
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None: ...
+    def __exit__(self, exc_type: None | builtins.type[BaseException], exc_val: None | BaseException, exc_tb: None | TracebackType) -> None: ...
 
 # Defined in torch/csrc/Event.cpp
 class Event:

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -36,7 +36,16 @@ from typing_extensions import ParamSpec as _ParamSpec, TypeIs as _TypeIs
 
 
 if TYPE_CHECKING:
-    from .types import Device, IntLikeType, _bool, _int, _float, FloatLikeType, _str, BoolLikeType
+    from .types import (
+        _bool,
+        _float,
+        _int,
+        _str,
+        BoolLikeType,
+        Device,
+        FloatLikeType,
+        IntLikeType,
+    )
 
 
 # As a bunch of torch.packages internally still have this check
@@ -454,48 +463,48 @@ class SymInt:
         if not isinstance(other, (builtins.int, SymInt)):
             return NotImplemented
         return self.__rint_truediv__(other)
-    
-    @_overload
-    def __floordiv__(self, other: "IntLikeType") -> "SymInt":
-        ...
-    @_overload
-    def __floordiv__(self, other: "FloatLikeType") -> "SymFloat":
-        ...
 
-    def __floordiv__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymFloat", "SymInt"]:
+    @_overload
+    def __floordiv__(self, other: "IntLikeType") -> "SymInt": ...
+    @_overload
+    def __floordiv__(self, other: "FloatLikeType") -> "SymFloat": ...
+
+    def __floordiv__(
+        self, other: _Union["IntLikeType", "FloatLikeType"]
+    ) -> _Union["SymFloat", "SymInt"]:
         if isinstance(other, (builtins.float, SymFloat)):
             return sym_float(math.floor(sym_float(self) / other))
         if not isinstance(other, (builtins.int, SymInt)):
             return NotImplemented
         return self.__int_floordiv__(other)
-    
+
     @_overload
-    def __rfloordiv__(self, other: "IntLikeType") -> "SymInt":
-        ...
+    def __rfloordiv__(self, other: "IntLikeType") -> "SymInt": ...
     @_overload
-    def __rfloordiv__(self, other: "FloatLikeType") -> "SymFloat":
-        ...
+    def __rfloordiv__(self, other: "FloatLikeType") -> "SymFloat": ...
 
     # type ignore likely a bug in mypy, see https://github.com/python/mypy/issues/18498
-    def __rfloordiv__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymFloat", "SymInt"]: # type: ignore[misc]
+    def __rfloordiv__(
+        self, other: _Union["IntLikeType", "FloatLikeType"]
+    ) -> _Union["SymFloat", "SymInt"]:  # type: ignore[misc]
         if isinstance(other, (builtins.float, SymFloat)):
             return sym_float(math.floor(other / sym_float(self)))
         if not isinstance(other, (builtins.int, SymInt)):
             return NotImplemented
         return self.__rint_floordiv__(other)
-    
+
     @_overload
-    def __pow__(self, other: "IntLikeType") -> "SymInt":
-        ...
+    def __pow__(self, other: "IntLikeType") -> "SymInt": ...
     @_overload
-    def __pow__(self, other: "FloatLikeType") -> "SymFloat":
-        ...
+    def __pow__(self, other: "FloatLikeType") -> "SymFloat": ...
 
     # nb: complex is impossible to handle correctly lol, with
     # negative base and integral float need to diverge semantics and
     # just always return complex.  Neener neener pretend this problem
     # doesn't exist
-    def __pow__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]:
+    def __pow__(
+        self, other: _Union["IntLikeType", "FloatLikeType"]
+    ) -> _Union["SymInt", "SymFloat"]:
         if isinstance(other, (builtins.float, SymFloat)):
             return sym_float(self).__pow__(other)
         if not isinstance(other, (builtins.int, SymInt)):
@@ -520,14 +529,14 @@ class SymInt:
             return sym_float(self).__pow__(sym_float(other))
 
     @_overload
-    def __rpow__(self, other: "IntLikeType") -> "SymInt":
-        ...
+    def __rpow__(self, other: "IntLikeType") -> "SymInt": ...
     @_overload
-    def __rpow__(self, other: "FloatLikeType") -> "SymFloat":
-        ...
+    def __rpow__(self, other: "FloatLikeType") -> "SymFloat": ...
 
     # type ignore likely a bug in mypy, see https://github.com/python/mypy/issues/18498
-    def __rpow__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]: # type: ignore[misc]
+    def __rpow__(
+        self, other: _Union["IntLikeType", "FloatLikeType"]
+    ) -> _Union["SymInt", "SymFloat"]:  # type: ignore[misc]
         if isinstance(other, (builtins.float, SymFloat)):
             return sym_float(self).__rpow__(other)
         if not isinstance(other, (builtins.int, SymInt)):
@@ -537,7 +546,7 @@ class SymInt:
         else:
             return sym_float(self).__rpow__(sym_float(other))
 
-    def __eq__(self, other: _Any) -> "_bool":
+    def __eq__(self, other: object) -> "_bool":
         raise TypeError("type stub not overridden")
 
     def __lt__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> "_bool":
@@ -551,121 +560,125 @@ class SymInt:
 
     def __ge__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> "_bool":
         raise TypeError("type stub not overridden")
-    
-    @_overload
-    def __add__(self, other: "IntLikeType") -> "SymInt":
-        ...
-    @_overload
-    def __add__(self, other: "FloatLikeType") -> "SymFloat":
-        ...
 
-    def __add__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]:
-        raise TypeError("type stub not overridden")
-    
     @_overload
-    def __radd__(self, other: "IntLikeType") -> "SymInt":
-        ...
+    def __add__(self, other: "IntLikeType") -> "SymInt": ...
     @_overload
-    def __radd__(self, other: "FloatLikeType") -> "SymFloat":
-        ...
+    def __add__(self, other: "FloatLikeType") -> "SymFloat": ...
 
-    def __radd__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]:
-        raise TypeError("type stub not overridden")
-    
-    @_overload
-    def __rmul__(self, other: "IntLikeType") -> "SymInt":
-        ...
-    @_overload
-    def __rmul__(self, other: "FloatLikeType") -> "SymFloat":
-        ...
-
-    def __rmul__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]:
-        raise TypeError("type stub not overridden")
-    
-    @_overload
-    def __mod__(self, other: "IntLikeType") -> "SymInt":
-        ...
-    @_overload
-    def __mod__(self, other: "FloatLikeType") -> "SymFloat":
-        ...
-
-    def __mod__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]:
+    def __add__(
+        self, other: _Union["IntLikeType", "FloatLikeType"]
+    ) -> _Union["SymInt", "SymFloat"]:
         raise TypeError("type stub not overridden")
 
     @_overload
-    def __mul__(self, other: "IntLikeType") -> "SymInt":
-        ...
+    def __radd__(self, other: "IntLikeType") -> "SymInt": ...
     @_overload
-    def __mul__(self, other: "FloatLikeType") -> "SymFloat":
-        ...
-        
-    def __mul__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]:
-        raise TypeError("type stub not overridden")
-    
-    @_overload
-    def __pow_by_natural__(self, other: "IntLikeType") -> "SymInt":
-        ...
-    @_overload
-    def __pow_by_natural__(self, other: "FloatLikeType") -> "SymFloat":
-        ...
+    def __radd__(self, other: "FloatLikeType") -> "SymFloat": ...
 
-    def __pow_by_natural__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> _Union["SymInt", "SymFloat"]:
+    def __radd__(
+        self, other: _Union["IntLikeType", "FloatLikeType"]
+    ) -> _Union["SymInt", "SymFloat"]:
         raise TypeError("type stub not overridden")
 
     @_overload
-    def __rpow_by_natural__(self, other: "IntLikeType") -> "SymInt":
-        ...
+    def __rmul__(self, other: "IntLikeType") -> "SymInt": ...
     @_overload
-    def __rpow_by_natural__(self, other: "FloatLikeType") -> "SymFloat":
-        ...
+    def __rmul__(self, other: "FloatLikeType") -> "SymFloat": ...
 
-    def __rpow_by_natural__(self, other:  _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]:
-        raise TypeError("type stub not overridden")
-
-    def __int_truediv__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
-        raise TypeError("type stub not overridden")
-
-    def __rint_truediv__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
-        raise TypeError("type stub not overridden")
-    
-    @_overload
-    def __int_floordiv__(self, other: "IntLikeType") -> "SymInt":
-        ...
-    @_overload
-    def __int_floordiv__(self, other: "FloatLikeType") -> "SymFloat":
-        ...
-
-    def __int_floordiv__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymFloat", "SymInt"]:
+    def __rmul__(
+        self, other: _Union["IntLikeType", "FloatLikeType"]
+    ) -> _Union["SymInt", "SymFloat"]:
         raise TypeError("type stub not overridden")
 
     @_overload
-    def __rint_floordiv__(self, other: "IntLikeType") -> "SymInt":
-        ...
+    def __mod__(self, other: "IntLikeType") -> "SymInt": ...
     @_overload
-    def __rint_floordiv__(self, other: "FloatLikeType") -> "SymFloat":
-        ...
+    def __mod__(self, other: "FloatLikeType") -> "SymFloat": ...
 
-    def __rint_floordiv__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymFloat", "SymInt"]:
-        raise TypeError("type stub not overridden")
-    
-    @_overload
-    def __sym_max__(self, other: "IntLikeType") -> "SymInt":
-        ...
-    @_overload
-    def __sym_max__(self, other: "FloatLikeType") -> "SymFloat":
-        ...
-
-    def __sym_max__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]:
+    def __mod__(
+        self, other: _Union["IntLikeType", "FloatLikeType"]
+    ) -> _Union["SymInt", "SymFloat"]:
         raise TypeError("type stub not overridden")
 
     @_overload
-    def __sym_min__(self, other: "IntLikeType") -> "SymInt":
-        ...
+    def __mul__(self, other: "IntLikeType") -> "SymInt": ...
     @_overload
-    def __sym_min__(self, other: "FloatLikeType") -> "SymFloat":
-        ...
+    def __mul__(self, other: "FloatLikeType") -> "SymFloat": ...
 
-    def __sym_min__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]:
+    def __mul__(
+        self, other: _Union["IntLikeType", "FloatLikeType"]
+    ) -> _Union["SymInt", "SymFloat"]:
+        raise TypeError("type stub not overridden")
+
+    @_overload
+    def __pow_by_natural__(self, other: "IntLikeType") -> "SymInt": ...
+    @_overload
+    def __pow_by_natural__(self, other: "FloatLikeType") -> "SymFloat": ...
+
+    def __pow_by_natural__(
+        self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]
+    ) -> _Union["SymInt", "SymFloat"]:
+        raise TypeError("type stub not overridden")
+
+    @_overload
+    def __rpow_by_natural__(self, other: "IntLikeType") -> "SymInt": ...
+    @_overload
+    def __rpow_by_natural__(self, other: "FloatLikeType") -> "SymFloat": ...
+
+    def __rpow_by_natural__(
+        self, other: _Union["IntLikeType", "FloatLikeType"]
+    ) -> _Union["SymInt", "SymFloat"]:
+        raise TypeError("type stub not overridden")
+
+    def __int_truediv__(
+        self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]
+    ) -> "SymFloat":
+        raise TypeError("type stub not overridden")
+
+    def __rint_truediv__(
+        self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]
+    ) -> "SymFloat":
+        raise TypeError("type stub not overridden")
+
+    @_overload
+    def __int_floordiv__(self, other: "IntLikeType") -> "SymInt": ...
+    @_overload
+    def __int_floordiv__(self, other: "FloatLikeType") -> "SymFloat": ...
+
+    def __int_floordiv__(
+        self, other: _Union["IntLikeType", "FloatLikeType"]
+    ) -> _Union["SymFloat", "SymInt"]:
+        raise TypeError("type stub not overridden")
+
+    @_overload
+    def __rint_floordiv__(self, other: "IntLikeType") -> "SymInt": ...
+    @_overload
+    def __rint_floordiv__(self, other: "FloatLikeType") -> "SymFloat": ...
+
+    def __rint_floordiv__(
+        self, other: _Union["IntLikeType", "FloatLikeType"]
+    ) -> _Union["SymFloat", "SymInt"]:
+        raise TypeError("type stub not overridden")
+
+    @_overload
+    def __sym_max__(self, other: "IntLikeType") -> "SymInt": ...
+    @_overload
+    def __sym_max__(self, other: "FloatLikeType") -> "SymFloat": ...
+
+    def __sym_max__(
+        self, other: _Union["IntLikeType", "FloatLikeType"]
+    ) -> _Union["SymInt", "SymFloat"]:
+        raise TypeError("type stub not overridden")
+
+    @_overload
+    def __sym_min__(self, other: "IntLikeType") -> "SymInt": ...
+    @_overload
+    def __sym_min__(self, other: "FloatLikeType") -> "SymFloat": ...
+
+    def __sym_min__(
+        self, other: _Union["IntLikeType", "FloatLikeType"]
+    ) -> _Union["SymInt", "SymFloat"]:
         raise TypeError("type stub not overridden")
 
     def __sym_float__(self) -> "SymFloat":
@@ -675,23 +688,23 @@ class SymInt:
         raise TypeError("type stub not overridden")
 
     @_overload
-    def __sub__(self, other: "IntLikeType") -> "SymInt":
-        ...
+    def __sub__(self, other: "IntLikeType") -> "SymInt": ...
     @_overload
-    def __sub__(self, other: "FloatLikeType") -> "SymFloat":
-        ...
+    def __sub__(self, other: "FloatLikeType") -> "SymFloat": ...
 
-    def __sub__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]:
+    def __sub__(
+        self, other: _Union["IntLikeType", "FloatLikeType"]
+    ) -> _Union["SymInt", "SymFloat"]:
         raise TypeError("type stub not overridden")
-    
-    @_overload
-    def __rsub__(self, other: "IntLikeType") -> "SymInt":
-        ...
-    @_overload
-    def __rsub__(self, other: "FloatLikeType") -> "SymFloat":
-        ...
 
-    def __rsub__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]:
+    @_overload
+    def __rsub__(self, other: "IntLikeType") -> "SymInt": ...
+    @_overload
+    def __rsub__(self, other: "FloatLikeType") -> "SymFloat": ...
+
+    def __rsub__(
+        self, other: _Union["IntLikeType", "FloatLikeType"]
+    ) -> _Union["SymInt", "SymFloat"]:
         raise TypeError("type stub not overridden")
 
     def __and__(self, other: _Union["IntLikeType", "_bool"]) -> "SymInt":
@@ -745,22 +758,30 @@ class SymFloat:
         # class has a field named node that stores SymNode
         self.node = node
 
-    def __truediv__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
+    def __truediv__(
+        self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]
+    ) -> "SymFloat":
         if not isinstance(other, (builtins.int, builtins.float, SymInt, SymFloat)):
             return NotImplemented
         return self.__float_truediv__(sym_float(other))
 
-    def __rtruediv__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
+    def __rtruediv__(
+        self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]
+    ) -> "SymFloat":
         if not isinstance(other, (builtins.int, builtins.float, SymInt, SymFloat)):
             return NotImplemented
         return self.__rfloat_truediv__(sym_float(other))
 
-    def __floordiv__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
+    def __floordiv__(
+        self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]
+    ) -> "SymFloat":
         if not isinstance(other, (builtins.int, builtins.float, SymInt, SymFloat)):
             return NotImplemented
         return sym_float(math.floor(self / sym_float(other)))
 
-    def __rfloordiv__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
+    def __rfloordiv__(
+        self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]
+    ) -> "SymFloat":
         if not isinstance(other, (builtins.int, builtins.float, SymInt, SymFloat)):
             return NotImplemented
         return sym_float(math.floor(sym_float(other) / self))
@@ -773,13 +794,17 @@ class SymFloat:
 
     # Symbolic power does NOT work with negative base, this is to avoid
     # potential complex outputs
-    def __pow__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
+    def __pow__(
+        self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]
+    ) -> "SymFloat":
         if not isinstance(other, (builtins.int, builtins.float, SymInt, SymFloat)):
             return NotImplemented
         torch._check(self >= 0)
         return self.__float_pow__(other)
 
-    def __rpow__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
+    def __rpow__(
+        self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]
+    ) -> "SymFloat":
         if not isinstance(other, (builtins.int, builtins.float, SymInt, SymFloat)):
             return NotImplemented
         torch._check(other >= 0)
@@ -787,7 +812,7 @@ class SymFloat:
 
     # Magic methods installed by torch.fx.experimental.sym_node
 
-    def __eq__(self, other: _Any) -> "_bool":
+    def __eq__(self, other: object) -> "_bool":
         raise TypeError("type stub not overridden")
 
     def __lt__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "_bool":
@@ -802,25 +827,37 @@ class SymFloat:
     def __ge__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "_bool":
         raise TypeError("type stub not overridden")
 
-    def __float_pow__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
+    def __float_pow__(
+        self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]
+    ) -> "SymFloat":
         raise TypeError("type stub not overridden")
 
-    def __rfloat_pow__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
+    def __rfloat_pow__(
+        self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]
+    ) -> "SymFloat":
         raise TypeError("type stub not overridden")
 
-    def __float_truediv__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
+    def __float_truediv__(
+        self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]
+    ) -> "SymFloat":
         raise TypeError("type stub not overridden")
 
-    def __rfloat_truediv__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
+    def __rfloat_truediv__(
+        self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]
+    ) -> "SymFloat":
         raise TypeError("type stub not overridden")
 
     def __trunc__(self) -> "SymInt":
         raise TypeError("type stub not overridden")
 
-    def __sym_max__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
+    def __sym_max__(
+        self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]
+    ) -> "SymFloat":
         raise TypeError("type stub not overridden")
 
-    def __sym_min__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
+    def __sym_min__(
+        self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]
+    ) -> "SymFloat":
         raise TypeError("type stub not overridden")
 
     def __sym_int__(self) -> "SymInt":
@@ -900,21 +937,28 @@ class SymBool:
     def __sym_not__(self) -> "SymBool":
         raise TypeError("type stub not overridden")
 
-
     # booleans behave like fixed-value ints in Python, type checker unable
     # to handle separate overloads for booleans and ints as a result
     @_overload
-    def __sym_ite__(self, then_val: _Union["IntLikeType", "BoolLikeType"], else_val: _Union["IntLikeType", "BoolLikeType"]) -> _Union["SymInt", "SymBool"]:
-        ...
+    def __sym_ite__(
+        self,
+        then_val: _Union["IntLikeType", "BoolLikeType"],
+        else_val: _Union["IntLikeType", "BoolLikeType"],
+    ) -> _Union["SymInt", "SymBool"]: ...
 
     @_overload
-    def __sym_ite__(self, then_val: "FloatLikeType", else_val: "FloatLikeType") -> "SymFloat":
-        ...
+    def __sym_ite__(
+        self, then_val: "FloatLikeType", else_val: "FloatLikeType"
+    ) -> "SymFloat": ...
 
-    def __sym_ite__(self, then_val: _Union["IntLikeType", "FloatLikeType", "BoolLikeType"], else_val: _Union["IntLikeType", "FloatLikeType", "BoolLikeType"]) -> _Union["SymInt", "SymFloat", "SymBool"]:
+    def __sym_ite__(
+        self,
+        then_val: _Union["IntLikeType", "FloatLikeType", "BoolLikeType"],
+        else_val: _Union["IntLikeType", "FloatLikeType", "BoolLikeType"],
+    ) -> _Union["SymInt", "SymFloat", "SymBool"]:
         raise TypeError("type stub not overridden")
 
-    def __eq__(self, other: _Any) -> "_bool":
+    def __eq__(self, other: object) -> "_bool":
         raise TypeError("type stub not overridden")
 
     def __repr__(self) -> "_str":

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -66,7 +66,7 @@ class Node(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def metadata(self) -> dict:
+    def metadata(self) -> dict[Any, Any]:
         r"""Return the metadata."""
         raise NotImplementedError
 
@@ -440,7 +440,11 @@ class _MultiHandle(RemovableHandle):
         for handle in self.handles:
             handle.remove()
 
-    def __getstate__(self) -> tuple[RemovableHandle, ...]:
+    # TODO: this subclass violates Liskov substitution principle
+    # also not clear why it needs to subclass RemovableHandle
+    # as it overrides all methods apart from context manager methods,
+    # confirm whether intentional and remove the type ignore if not
+    def __getstate__(self) -> tuple[RemovableHandle, ...]:  # type: ignore[override]
         return self.handles
 
     def __setstate__(self, state: tuple[RemovableHandle, ...]) -> None:

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -8,7 +8,19 @@ import functools
 import io
 import threading
 import warnings
-from typing import Any, cast, Optional as _Optional, TYPE_CHECKING, TypeVar, Union
+from collections.abc import Iterator, Sequence  # noqa: TC003
+from typing import (
+    Any,
+    Callable,
+    cast,
+    Literal,
+    Optional as _Optional,
+    overload,
+    Protocol,
+    TYPE_CHECKING,
+    TypeVar,
+    Union,
+)
 from typing_extensions import Self
 
 import torch
@@ -19,6 +31,13 @@ from torch.types import _bool, _int, Storage
 if TYPE_CHECKING:
     from torch._prims_common import DeviceLikeType
 
+
+class HasSparseFlag(Protocol):
+    is_sparse: _bool
+
+
+D = TypeVar("D", bound=HasSparseFlag)
+T = TypeVar("T", bound="Union[_StorageBase, TypedStorage]")
 
 __all__ = ["TypedStorage", "UntypedStorage"]
 
@@ -35,11 +54,9 @@ except ModuleNotFoundError:
 _share_memory_lock = threading.Lock()
 _share_memory_map: dict[int, threading.RLock] = {}
 
-T = TypeVar("T", bound="Union[_StorageBase, TypedStorage]")
-
 
 class _StorageBase:
-    _cdata: Any
+    _cdata: _int
     is_sparse: _bool = False
     is_sparse_csr: _bool = False
     device: torch.device
@@ -50,22 +67,63 @@ class _StorageBase:
     # Used when loading with FakeTensorMode to give information about offset of storage in torch.saved-file
     _checkpoint_offset: _Optional[int] = None
 
-    def __init__(self, *args, **kwargs):
+    # TODO: See if possible to include these overloads in some way
+    # @overload
+    # def __new__(cls, *, allocator: _int | None = None, device: DeviceLikeType | None = None) -> Self: ...
+
+    # @overload
+    # def __new__(cls, size: _int, *, allocator: _int | None = None, device: DeviceLikeType | None = None) -> Self: ...
+
+    # @overload
+    # def __new__(cls, sequence: Sequence[_int], *, allocator: _int | None = None, device: DeviceLikeType | None = None) -> Self: ...
+
+    @overload
+    def __init__(
+        self, *, allocator: _int | None = None, device: DeviceLikeType | None = None
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self,
+        size: _int,
+        *,
+        allocator: _int | None = None,
+        device: DeviceLikeType | None = None,
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self,
+        sequence: Sequence[_int],
+        *,
+        allocator: _int | None = None,
+        device: DeviceLikeType | None = None,
+    ) -> None: ...
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         pass
 
     def __len__(self) -> _int:
         raise NotImplementedError
 
-    def __getitem__(self, idx):
+    @overload
+    def __getitem__(self, idx: _int) -> _int: ...
+
+    @overload
+    def __getitem__(self, idx: slice) -> Self: ...
+
+    def __getitem__(self, idx: _int | slice) -> _int | Self:
         raise NotImplementedError
 
-    def __setitem__(self, *args, **kwargs):
+    def __setitem__(
+        self, idx: Union[_int, slice], value: _int, *args: Any, **kwargs: Any
+    ) -> None:
         raise NotImplementedError
 
-    def copy_(self, source: T, non_blocking: _Optional[_bool] = None) -> T:
+    def copy_(self, source: _StorageBase, non_blocking: _bool | None = None) -> Self:
         raise NotImplementedError
 
-    def new(self) -> Union[_StorageBase, TypedStorage]:
+    def new(self) -> Self:
         raise NotImplementedError
 
     def nbytes(self) -> _int:
@@ -74,14 +132,25 @@ class _StorageBase:
     def size(self) -> _int:
         return self.nbytes()
 
+    @overload
+    def type(self, dtype: None = None, non_blocking: _bool = False) -> str: ...
+
+    @overload
+    def type(self, dtype: type[Self], non_blocking: _bool = False) -> Self: ...
+
+    @overload
+    def type(self, dtype: type[D], non_blocking: _bool = False) -> D: ...
+
+    # deliberately ignoring str overload as flaky - assumes str importable
+    # and that imported object has `is_sparse` attribute
     def type(
-        self, dtype: _Optional[str] = None, non_blocking: _bool = False
-    ) -> Union[_StorageBase, TypedStorage]:
+        self, dtype: type[Self] | type[D] | None = None, non_blocking: _bool = False
+    ) -> Union[str, Self, D]:
         return _type(self, dtype, non_blocking)
 
     def cuda(
-        self, device=None, non_blocking=False
-    ) -> Union[_StorageBase, TypedStorage]:
+        self, device: int | None = None, non_blocking: _bool = False
+    ) -> Union[_StorageBase, Self]:
         """Returns a copy of this object in CUDA memory.
 
         If this object is already in CUDA memory and on the correct device, then
@@ -96,7 +165,9 @@ class _StorageBase:
         device2 = torch.device("cuda", device) if device else torch.device("cuda")
         return self.to(device=device2, non_blocking=non_blocking)
 
-    def hpu(self, device=None, non_blocking=False) -> Union[_StorageBase, TypedStorage]:
+    def hpu(
+        self, device: int | None = None, non_blocking: _bool = False
+    ) -> Union[_StorageBase, Self]:
         """Returns a copy of this object in HPU memory.
 
         If this object is already in HPU memory and on the correct device, then
@@ -139,7 +210,16 @@ class _StorageBase:
         raise NotImplementedError
 
     @classmethod
-    def from_buffer(cls, *args, **kwargs) -> Self:
+    def from_buffer(
+        cls,
+        dbuffer: Any,
+        *args: Any,
+        byte_order: Literal["native", "little", "big"] = "native",
+        count: _int = -1,
+        offset: _int = 0,
+        type: torch.dtype,
+        **kwargs: Any,
+    ) -> UntypedStorage:
         raise NotImplementedError
 
     @classmethod
@@ -172,7 +252,7 @@ class _StorageBase:
     def _write_file(self, *args, **kwargs):
         raise NotImplementedError
 
-    def resize_(self, size: _int):
+    def resize_(self, size: _int) -> Self:
         raise NotImplementedError
 
     def _weak_ref(self, *args, **kwargs) -> Union[_StorageBase, TypedStorage]:
@@ -202,15 +282,17 @@ class _StorageBase:
         raise NotImplementedError
 
     @property
-    def is_cuda(self):
+    def is_cuda(self) -> _bool:
         raise NotImplementedError
 
     @property
-    def is_hpu(self):
+    def is_hpu(self) -> _bool:
         raise NotImplementedError
 
     @classmethod
-    def from_file(cls, filename, shared, nbytes) -> Union[_StorageBase, TypedStorage]:
+    def from_file(
+        cls, filename: str, shared: _bool = False, nbytes: _int = -0
+    ) -> UntypedStorage:
         raise NotImplementedError
 
     @classmethod
@@ -223,50 +305,50 @@ class _StorageBase:
     def _get_filename(self, *args, **kwargs) -> _Optional[str]:
         raise NotImplementedError
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         info_str = f"[{torch.typename(self)}(device={self.device}) of size {len(self)}]"
         if self.device.type == "meta":
             return "...\n" + info_str
         data_str = " " + "\n ".join(str(self[i]) for i in range(self.size()))
         return data_str + "\n" + info_str
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[_int]:
         return iter(self[i] for i in range(self.size()))
 
-    def __copy__(self):
+    def __copy__(self) -> Self:
         return self.clone()
 
-    def __deepcopy__(self, memo):
-        memo = memo.setdefault("torch", {})
+    def __deepcopy__(self, memo: dict[Literal["torch"], dict[int, Any]]) -> Self:
+        memo: dict[int, Any] = memo.setdefault("torch", {})
         if self._cdata in memo:
             return memo[self._cdata]
         new_storage = self.clone()
         memo[self._cdata] = new_storage
         return new_storage
 
-    def __reduce__(self):
+    def __reduce__(self) -> tuple[Callable[[bytes], Self], tuple[bytes]]:
         b = io.BytesIO()
         torch.save(self, b, _use_new_zipfile_serialization=False)
         return (_load_from_bytes, (b.getvalue(),))
 
-    def __sizeof__(self):
+    def __sizeof__(self) -> _int:
         return super().__sizeof__() + self.size()
 
-    def clone(self):
+    def clone(self) -> Self:
         """Return a copy of this storage."""
         return type(self)(self.nbytes(), device=self.device).copy_(self)
 
-    def tolist(self):
+    def tolist(self) -> list[_int]:
         """Return a list containing the elements of this storage."""
         return list(self)
 
-    def cpu(self):
+    def cpu(self) -> Self | UntypedStorage:
         """Return a CPU copy of this storage if it's not already on the CPU."""
         if self.device.type != "cpu":
             return torch.UntypedStorage(self.size()).copy_(self, False)
         return self
 
-    def mps(self):
+    def mps(self) -> Self | UntypedStorage:
         """Return a MPS copy of this storage if it's not already on the MPS."""
         if self.device.type != "mps":
             return torch.UntypedStorage(self.size(), device="mps").copy_(self, False)
@@ -285,76 +367,78 @@ class _StorageBase:
             storage = storage.clone()
         return storage
 
-    def to(self, *, device: DeviceLikeType, non_blocking: _bool = False):
+    def to(
+        self, *, device: DeviceLikeType, non_blocking: _bool = False
+    ) -> UntypedStorage:
         if not isinstance(device, torch.device):
             device = torch.device(device)
         return _to(self, device, non_blocking)
 
-    def double(self):
+    def double(self) -> UntypedStorage:
         """Casts this storage to double type."""
         return self._to(torch.double)
 
-    def float(self):
+    def float(self) -> UntypedStorage:
         """Casts this storage to float type."""
         return self._to(torch.float)
 
-    def half(self):
+    def half(self) -> UntypedStorage:
         """Casts this storage to half type."""
         return self._to(torch.half)
 
-    def long(self):
+    def long(self) -> UntypedStorage:
         """Casts this storage to long type."""
         return self._to(torch.long)
 
-    def int(self):
+    def int(self) -> UntypedStorage:
         """Casts this storage to int type."""
         return self._to(torch.int)
 
-    def short(self):
+    def short(self) -> UntypedStorage:
         """Casts this storage to short type."""
         return self._to(torch.short)
 
-    def char(self):
+    def char(self) -> UntypedStorage:
         """Casts this storage to char type."""
         return self._to(torch.int8)
 
-    def byte(self):
+    def byte(self) -> UntypedStorage:
         """Casts this storage to byte type."""
         return self._to(torch.uint8)
 
-    def bool(self):
+    def bool(self) -> UntypedStorage:
         """Casts this storage to bool type."""
         return self._to(torch.bool)
 
-    def bfloat16(self):
+    def bfloat16(self) -> UntypedStorage:
         """Casts this storage to bfloat16 type."""
         return self._to(torch.bfloat16)
 
-    def complex_double(self):
+    def complex_double(self) -> UntypedStorage:
         """Casts this storage to complex double type."""
         return self._to(torch.cdouble)
 
-    def complex_float(self):
+    def complex_float(self) -> UntypedStorage:
         """Casts this storage to complex float type."""
         return self._to(torch.cfloat)
 
-    def float8_e5m2(self):
+    def float8_e5m2(self) -> UntypedStorage:
         """Casts this storage to float8_e5m2 type"""
         return self._to(torch.float8_e5m2)
 
-    def float8_e4m3fn(self):
+    def float8_e4m3fn(self) -> UntypedStorage:
         """Casts this storage to float8_e4m3fn type"""
         return self._to(torch.float8_e4m3fn)
 
-    def float8_e5m2fnuz(self):
+    def float8_e5m2fnuz(self) -> UntypedStorage:
         """Casts this storage to float8_e5m2fnuz type"""
         return self._to(torch.float8_e5m2fnuz)
 
-    def float8_e4m3fnuz(self):
+    def float8_e4m3fnuz(self) -> UntypedStorage:
         """Casts this storage to float8_e4m3fnuz type"""
         return self._to(torch.float8_e4m3fnuz)
 
-    def is_pinned(self, device: Union[str, torch.device] = "cuda"):
+    def is_pinned(self, device: DeviceLikeType = "cuda") -> _bool:
         r"""Determine whether the CPU storage is already pinned on device.
 
         Args:
@@ -370,7 +454,7 @@ class _StorageBase:
             .is_pinned(device)
         )
 
-    def pin_memory(self, device: Union[str, torch.device] = "cuda"):
+    def pin_memory(self, device: DeviceLikeType = "cuda") -> UntypedStorage:
         r"""Copy the CPU storage to pinned memory, if it's not already pinned.
 
         Args:
@@ -390,7 +474,7 @@ class _StorageBase:
         )
         return pinned_tensor.untyped_storage()
 
-    def share_memory_(self):
+    def share_memory_(self) -> Self:
         """See :meth:`torch.UntypedStorage.share_memory_`"""
         from torch.multiprocessing import get_sharing_strategy
 
@@ -415,10 +499,10 @@ class _StorageBase:
         else:
             return cls._new_using_fd_cpu(size)
 
-    def untyped(self):
+    def untyped(self) -> Self:
         return self
 
-    def byteswap(self, dtype):
+    def byteswap(self, dtype: torch.dtype) -> None:
         """Swap bytes in underlying data."""
         elem_size = torch._utils._element_size(dtype)
         # for complex types, don't swap first and second numbers
@@ -427,7 +511,7 @@ class _StorageBase:
         self._byteswap(elem_size)
 
 
-def _share_memory_lock_protected(fn):
+def _share_memory_lock_protected(fn: Callable[..., Any]) -> Callable[..., Any]:
     @functools.wraps(fn)
     def wrapper(self, *args, **kwargs):
         to_free = None
@@ -464,21 +548,27 @@ def _share_memory_lock_protected(fn):
 
 
 class UntypedStorage(torch._C.StorageBase, _StorageBase):
-    def __getitem__(self, *args, **kwargs):
+    @overload
+    def __getitem__(self, idx: _int) -> _int: ...
+
+    @overload
+    def __getitem__(self, idx: slice) -> Self: ...
+
+    def __getitem__(self, *args: Any, **kwargs: Any) -> _int | Self:
         if self.device.type == "meta":
             raise NotImplementedError("Not available for 'meta' device type")
         return super().__getitem__(*args, **kwargs)
 
     @property
-    def is_cuda(self):
+    def is_cuda(self) -> _bool:
         return self.device.type == "cuda"
 
     @property
-    def is_hpu(self):
+    def is_hpu(self) -> _bool:
         return self.device.type == "hpu"
 
     @property
-    def filename(self) -> _Optional[str]:
+    def filename(self) -> str | None:
         """Returns the file name associated with this storage.
 
         The file name will be a string if the storage is on CPU and was created via
@@ -486,8 +576,9 @@ class UntypedStorage(torch._C.StorageBase, _StorageBase):
         """
         return self._get_filename()
 
+    # TODOL what happens if args or kwargs are passed here?
     @_share_memory_lock_protected
-    def share_memory_(self, *args, **kwargs):
+    def share_memory_(self, *args: Any, **kwargs: Any) -> Self:
         """
         Moves the storage to shared memory.
 
@@ -958,13 +1049,13 @@ class TypedStorage:
             tmp_tensor = torch.tensor(
                 [], dtype=tmp_dtype, device=self._untyped_storage.device
             )
-            tmp_tensor.set_(
+            tmp_tensor.set_(  # type: ignore[call-overload]
                 TypedStorage(
                     wrap_storage=self._untyped_storage, dtype=tmp_dtype, _internal=True
                 )
             )
         else:
-            tmp_tensor = torch.tensor(
+            tmp_tensor = torch.tensor(  # type: ignore[call-overload]
                 [], dtype=self.dtype, device=self._untyped_storage.device
             ).set_(self)
 
@@ -1013,7 +1104,7 @@ class TypedStorage:
         from torch._subclasses.fake_tensor import unset_fake_temporarily
 
         with unset_fake_temporarily():
-            tmp_tensor = torch.tensor(
+            tmp_tensor = torch.tensor(  # type: ignore[call-overload]
                 [], dtype=self.dtype, device=self._untyped_storage.device
             ).set_(self)
             return tmp_tensor[idx_wrapped].item()
@@ -1049,7 +1140,7 @@ class TypedStorage:
             return ".".join([self.__module__, type(self).__name__])
 
         else:
-            return self._untyped_storage.type(dtype, non_blocking)
+            return self._untyped_storage.type(dtype, non_blocking)  # type: ignore[call-overload]
 
     def cuda(self, device=None, non_blocking=False) -> Self:
         _warn_typed_storage_removal()
@@ -1311,7 +1402,7 @@ class TypedStorage:
             raise TypeError(f"Argument 'dtype' must be torch.dtype, not {type(dtype)}")
         storage = (
             torch.tensor([], dtype=self.dtype, device=self.device)
-            .set_(self)
+            .set_(self)  # type: ignore[call-overload]
             .to(dtype)
             ._typed_storage()
         )

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2373,7 +2373,7 @@ def to_gpu(obj, type_map=None):
             res.requires_grad = obj.requires_grad
         return res
     elif torch.is_storage(obj):
-        return obj.new().resize_(obj.size()).copy_(obj)  # type: ignore[attr-defined, union-attr]
+        return obj.new().resize_(obj.size()).copy_(obj)  # type: ignore[union-attr, arg-type]
     elif isinstance(obj, list):
         return [to_gpu(o, type_map) for o in obj]
     elif isinstance(obj, tuple):

--- a/torch/utils/hooks.py
+++ b/torch/utils/hooks.py
@@ -3,7 +3,12 @@ import torch
 from collections import OrderedDict
 import weakref
 import warnings
-from typing import Any
+from typing import Any, Callable, Union, TypeAlias
+from collections.abc import MutableMapping
+from types import TracebackType
+
+HooksDict: TypeAlias = MutableMapping[int, Callable[..., Any]]
+ExtraDict: TypeAlias = MutableMapping[int, Any]
 
 __all__ = ["RemovableHandle", "unserializable_hook", "warn_if_has_hooks", "BackwardHook"]
 
@@ -12,8 +17,8 @@ class RemovableHandle:
     A handle which provides the capability to remove a hook.
 
     Args:
-        hooks_dict (dict): A dictionary of hooks, indexed by hook ``id``.
-        extra_dict (Union[dict, List[dict]]): An additional dictionary or list of
+        hooks_dict: A dictionary of hooks, indexed by hook ``id``.
+        extra_dict: An additional dictionary or list of
             dictionaries whose keys will be deleted when the same keys are
             removed from ``hooks_dict``.
     """
@@ -21,12 +26,12 @@ class RemovableHandle:
     id: int
     next_id: int = 0
 
-    def __init__(self, hooks_dict: Any, *, extra_dict: Any = None) -> None:
-        self.hooks_dict_ref = weakref.ref(hooks_dict)
+    def __init__(self, hooks_dict: HooksDict, *, extra_dict: Union[ExtraDict, list[ExtraDict]] | None = None) -> None:
+        self.hooks_dict_ref: weakref.ref[HooksDict] = weakref.ref(hooks_dict)
         self.id = RemovableHandle.next_id
         RemovableHandle.next_id += 1
 
-        self.extra_dict_ref: tuple = ()
+        self.extra_dict_ref: tuple[weakref.ref[ExtraDict], ...] = ()
         if isinstance(extra_dict, dict):
             self.extra_dict_ref = (weakref.ref(extra_dict),)
         elif isinstance(extra_dict, list):
@@ -42,13 +47,17 @@ class RemovableHandle:
             if extra_dict is not None and self.id in extra_dict:
                 del extra_dict[self.id]
 
-    def __getstate__(self):
+    def __getstate__(self) -> Union[
+    tuple[HooksDict | None, int],
+    tuple[HooksDict | None, int, tuple[ExtraDict | None, ...]]
+]:
+        # TODO: this condition is never true, investigate fix
         if self.extra_dict_ref is None:
             return (self.hooks_dict_ref(), self.id)
         else:
             return (self.hooks_dict_ref(), self.id, tuple(ref() for ref in self.extra_dict_ref))
 
-    def __setstate__(self, state) -> None:
+    def __setstate__(self, state: Any) -> None:
         if state[0] is None:
             # create a dead reference
             self.hooks_dict_ref = weakref.ref(OrderedDict())
@@ -65,7 +74,7 @@ class RemovableHandle:
     def __enter__(self) -> "RemovableHandle":
         return self
 
-    def __exit__(self, type: Any, value: Any, tb: Any) -> None:
+    def __exit__(self, type:  None | type[BaseException], value: None | BaseException, tb: None | TracebackType) -> None:
         self.remove()
 
 


### PR DESCRIPTION
This PR updates the `torch.Tensor` stub template file so that it is type complete (all public methods now have type annotations).