### PR TITLE
Add type annotations to Sym* classes

### DIFF
--- a/diff_pyright_device_type_complete_type_sym_classes.diff
+++ b/diff_pyright_device_type_complete_type_sym_classes.diff
@@ -1,0 +1,6237 @@
+3c3
+<     "time": "1755650891600",
+---
+>     "time": "1755707361009",
+10c10
+<         "timeInSec": 8.848
+---
+>         "timeInSec": 8.975
+20c20
+<             "withKnownType": 6230,
+---
+>             "withKnownType": 6349,
+22c22
+<             "withUnknownType": 8954
+---
+>             "withUnknownType": 8835
+25,27c25,27
+<             "withKnownType": 2828,
+<             "withAmbiguousType": 136,
+<             "withUnknownType": 2239
+---
+>             "withKnownType": 2841,
+>             "withAmbiguousType": 141,
+>             "withUnknownType": 2221
+32c32
+<         "completenessScore": 0.389277680579855,
+---
+>         "completenessScore": 0.3967133216695826,
+11290c11290
+<                         "message": "Type of parameter \"other\" is partially unknown\n  Parameter type is \"Tensor | int | float | bool | complex | SymInt | SymFloat\"\n    Type argument 1 for class \"SymInt\" has unknown type\n    Type argument 1 for class \"SymFloat\" has unknown type",
+---
+>                         "message": "Type of parameter \"other\" is partially unknown\n  Parameter type is \"Tensor | int | float | bool | complex | SymInt | SymFloat\"",
+11337c11337
+<                 "referenceCount": 287,
+---
+>                 "referenceCount": 345,
+11339c11339
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+11351c11351
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+11353,11369c11353
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"node\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 424,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 424,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+11376c11360
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+11378,11394c11362
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 429,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 429,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+11401c11369
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+11403,11419c11371
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 432,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 432,
+<                                 "character": 15
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+11426c11378
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+11428,11444c11380
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 435,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 435,
+<                                 "character": 17
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+11451c11387
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+11453,11484c11389
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"ndigits\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 440,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 440,
+<                                 "character": 17
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 440,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 440,
+<                                 "character": 17
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+11491c11396
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+11493,11523c11398,11409
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 443,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 443,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 443,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 443,
+<                                 "character": 19
+<                             }
+<                         }
+<                     }
+---
+>                 "diagnostics": []
+>             },
+>             {
+>                 "category": "class",
+>                 "name": "torch.SymFloat",
+>                 "referenceCount": 139,
+>                 "isExported": true,
+>                 "isTypeKnown": true,
+>                 "isTypeAmbiguous": false,
+>                 "diagnostics": [],
+>                 "alternateNames": [
+>                     "torch.types.SymFloat"
+11528c11414
+<                 "name": "torch.SymInt.__rtruediv__",
+---
+>                 "name": "torch.SymFloat.__init__",
+11531c11417
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+11533,11564c11419
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 450,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 450,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 450,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 450,
+<                                 "character": 20
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+11568c11423
+<                 "name": "torch.SymInt.__floordiv__",
+---
+>                 "name": "torch.SymFloat.__truediv__",
+11571c11426
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+11573,11604c11428
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 457,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 457,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 457,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 457,
+<                                 "character": 20
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+11608c11432
+<                 "name": "torch.SymInt.__rfloordiv__",
+---
+>                 "name": "torch.SymFloat.__rtruediv__",
+11611c11435
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+11613,11644c11437
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 464,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 464,
+<                                 "character": 21
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 464,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 464,
+<                                 "character": 21
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+11648c11441
+<                 "name": "torch.SymInt.__pow__",
+---
+>                 "name": "torch.SymFloat.__floordiv__",
+11651c11444
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+11653,11684c11446
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 475,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 475,
+<                                 "character": 15
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 475,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 475,
+<                                 "character": 15
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+11688c11450
+<                 "name": "torch.SymInt.__rpow__",
+---
+>                 "name": "torch.SymFloat.__rfloordiv__",
+11691c11453
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+11693,11724c11455
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 499,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 499,
+<                                 "character": 16
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 499,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 499,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+11728c11459
+<                 "name": "torch.SymInt.__eq__",
+---
+>                 "name": "torch.SymFloat.__bool__",
+11737c11468
+<                 "name": "torch.SymInt.__lt__",
+---
+>                 "name": "torch.SymFloat.__float__",
+11740c11471
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+11742,11758c11473
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 512,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 512,
+<                                 "character": 14
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+11762c11477
+<                 "name": "torch.SymInt.__gt__",
+---
+>                 "name": "torch.SymFloat.__pow__",
+11765c11480
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+11767,11783c11482
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 515,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 515,
+<                                 "character": 14
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+11787c11486
+<                 "name": "torch.SymInt.__le__",
+---
+>                 "name": "torch.SymFloat.__rpow__",
+11790c11489
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+11792,11808c11491
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 518,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 518,
+<                                 "character": 14
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+11812c11495
+<                 "name": "torch.SymInt.__ge__",
+---
+>                 "name": "torch.SymFloat.__eq__",
+11815c11498
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+11817,11833c11500
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 521,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 521,
+<                                 "character": 14
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+11837c11504
+<                 "name": "torch.SymInt.__add__",
+---
+>                 "name": "torch.SymFloat.__lt__",
+11840c11507
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+11842,11858c11509
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 524,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 524,
+<                                 "character": 15
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+11862c11513
+<                 "name": "torch.SymInt.__radd__",
+---
+>                 "name": "torch.SymFloat.__gt__",
+11865c11516
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+11867,11883c11518
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 527,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 527,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+11887c11522
+<                 "name": "torch.SymInt.__rmul__",
+---
+>                 "name": "torch.SymFloat.__le__",
+11890c11525
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+11892,11908c11527
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 530,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 530,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+11912c11531
+<                 "name": "torch.SymInt.__mod__",
+---
+>                 "name": "torch.SymFloat.__ge__",
+11921c11540
+<                 "name": "torch.SymInt.__mul__",
+---
+>                 "name": "torch.SymFloat.__float_pow__",
+11924c11543
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+11926,11942c11545
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 536,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 536,
+<                                 "character": 15
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+11946c11549
+<                 "name": "torch.SymInt.__pow_by_natural__",
+---
+>                 "name": "torch.SymFloat.__rfloat_pow__",
+11949c11552
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+11951,11967c11554
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 539,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 539,
+<                                 "character": 26
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+11971c11558
+<                 "name": "torch.SymInt.__rpow_by_natural__",
+---
+>                 "name": "torch.SymFloat.__float_truediv__",
+11974c11561
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+11976,11992c11563
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 542,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 542,
+<                                 "character": 27
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+11996c11567
+<                 "name": "torch.SymInt.__int_truediv__",
+---
+>                 "name": "torch.SymFloat.__rfloat_truediv__",
+11999c11570
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12001,12032c11572,11581
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 545,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 545,
+<                                 "character": 23
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"SymFloat\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 545,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 545,
+<                                 "character": 23
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+>             },
+>             {
+>                 "category": "method",
+>                 "name": "torch.SymFloat.__trunc__",
+>                 "referenceCount": 1,
+>                 "isExported": true,
+>                 "isTypeKnown": true,
+>                 "isTypeAmbiguous": false,
+>                 "diagnostics": []
+12034a11584,11619
+>                 "category": "method",
+>                 "name": "torch.SymFloat.__sym_max__",
+>                 "referenceCount": 1,
+>                 "isExported": true,
+>                 "isTypeKnown": true,
+>                 "isTypeAmbiguous": false,
+>                 "diagnostics": []
+>             },
+>             {
+>                 "category": "method",
+>                 "name": "torch.SymFloat.__sym_min__",
+>                 "referenceCount": 1,
+>                 "isExported": true,
+>                 "isTypeKnown": true,
+>                 "isTypeAmbiguous": false,
+>                 "diagnostics": []
+>             },
+>             {
+>                 "category": "method",
+>                 "name": "torch.SymFloat.__sym_int__",
+>                 "referenceCount": 1,
+>                 "isExported": true,
+>                 "isTypeKnown": true,
+>                 "isTypeAmbiguous": false,
+>                 "diagnostics": []
+>             },
+>             {
+>                 "category": "method",
+>                 "name": "torch.SymFloat.is_integer",
+>                 "referenceCount": 1,
+>                 "isExported": true,
+>                 "isTypeKnown": true,
+>                 "isTypeAmbiguous": false,
+>                 "diagnostics": []
+>             },
+>             {
+12036,12037c11621,11622
+<                 "name": "torch.SymFloat",
+<                 "referenceCount": 69,
+---
+>                 "name": "torch.SymBool",
+>                 "referenceCount": 68,
+12039c11624
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12043c11628
+<                     "torch.types.SymFloat"
+---
+>                     "torch.types.SymBool"
+12048c11633
+<                 "name": "torch.SymFloat.__init__",
+---
+>                 "name": "torch.SymBool.__init__",
+12051c11636
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12053,12069c11638
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"node\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 621,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 621,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12073c11642
+<                 "name": "torch.SymFloat.__truediv__",
+---
+>                 "name": "torch.SymBool.__bool__",
+12076c11645
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12078,12109c11647
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 626,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 626,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 626,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 626,
+<                                 "character": 19
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12113c11651
+<                 "name": "torch.SymFloat.__rtruediv__",
+---
+>                 "name": "torch.SymBool.__int__",
+12116c11654
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12118,12149c11656
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 631,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 631,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 631,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 631,
+<                                 "character": 20
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12153c11660
+<                 "name": "torch.SymFloat.__floordiv__",
+---
+>                 "name": "torch.SymBool.__and__",
+12156c11663
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12158,12189c11665
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 636,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 636,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 636,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 636,
+<                                 "character": 20
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12193c11669
+<                 "name": "torch.SymFloat.__rfloordiv__",
+---
+>                 "name": "torch.SymBool.__or__",
+12196c11672
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12198,12229c11674
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 641,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 641,
+<                                 "character": 21
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 641,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 641,
+<                                 "character": 21
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12233c11678
+<                 "name": "torch.SymFloat.__bool__",
+---
+>                 "name": "torch.SymBool.__sym_not__",
+12236c11681
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12238,12254c11683
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 646,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 646,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12258c11687
+<                 "name": "torch.SymFloat.__float__",
+---
+>                 "name": "torch.SymBool.__sym_ite__",
+12261c11690
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12263,12279c11692
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 649,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 649,
+<                                 "character": 17
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12283c11696
+<                 "name": "torch.SymFloat.__pow__",
+---
+>                 "name": "torch.SymBool.__eq__",
+12286c11699
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12288,12319c11701
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 654,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 654,
+<                                 "character": 15
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 654,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 654,
+<                                 "character": 15
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12323c11705
+<                 "name": "torch.SymFloat.__rpow__",
+---
+>                 "name": "torch.SymBool.__repr__",
+12326c11708
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12328,12359c11710
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 660,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 660,
+<                                 "character": 16
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 660,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 660,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12363c11714
+<                 "name": "torch.SymFloat.__eq__",
+---
+>                 "name": "torch.SymBool.__hash__",
+12370a11722,11730
+>                 "category": "variable",
+>                 "name": "torch.SymBool.node",
+>                 "referenceCount": 1,
+>                 "isExported": true,
+>                 "isTypeKnown": true,
+>                 "isTypeAmbiguous": false,
+>                 "diagnostics": []
+>             },
+>             {
+12372c11732
+<                 "name": "torch.SymFloat.__lt__",
+---
+>                 "name": "torch.SymFloat.as_integer_ratio",
+12375c11735
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12377,12393c11737
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 671,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 671,
+<                                 "character": 14
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12397c11741
+<                 "name": "torch.SymFloat.__gt__",
+---
+>                 "name": "torch.SymFloat.__repr__",
+12400c11744
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12402,12418c11746
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 674,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 674,
+<                                 "character": 14
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12422c11750
+<                 "name": "torch.SymFloat.__le__",
+---
+>                 "name": "torch.SymFloat.__hash__",
+12425c11753
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12427,12443c11755
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 677,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 677,
+<                                 "character": 14
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12447c11759
+<                 "name": "torch.SymFloat.__ge__",
+---
+>                 "name": "torch.SymFloat.conjugate",
+12450c11762
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12452,12468c11764
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 680,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 680,
+<                                 "character": 14
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12472c11768
+<                 "name": "torch.SymFloat.__float_pow__",
+---
+>                 "name": "torch.SymFloat.hex",
+12475c11771
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12477,12493c11773
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 683,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 683,
+<                                 "character": 21
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12495a11776,11784
+>                 "category": "variable",
+>                 "name": "torch.SymFloat.node",
+>                 "referenceCount": 1,
+>                 "isExported": true,
+>                 "isTypeKnown": true,
+>                 "isTypeAmbiguous": false,
+>                 "diagnostics": []
+>             },
+>             {
+12497c11786
+<                 "name": "torch.SymFloat.__rfloat_pow__",
+---
+>                 "name": "torch.SymInt.__rtruediv__",
+12500c11789
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12502,12518c11791
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 686,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 686,
+<                                 "character": 22
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12522c11795
+<                 "name": "torch.SymFloat.__float_truediv__",
+---
+>                 "name": "torch.SymInt.__floordiv__",
+12525c11798
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12527,12543c11800
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 689,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 689,
+<                                 "character": 25
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12547c11804
+<                 "name": "torch.SymFloat.__rfloat_truediv__",
+---
+>                 "name": "torch.SymInt.__rfloordiv__",
+12550c11807
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12552,12568c11809
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 692,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 692,
+<                                 "character": 26
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12572c11813
+<                 "name": "torch.SymFloat.__trunc__",
+---
+>                 "name": "torch.SymInt.__pow__",
+12575c11816
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12577,12593c11818,11854
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 695,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 695,
+<                                 "character": 17
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+>             },
+>             {
+>                 "category": "method",
+>                 "name": "torch.SymInt.__rpow__",
+>                 "referenceCount": 1,
+>                 "isExported": true,
+>                 "isTypeKnown": true,
+>                 "isTypeAmbiguous": false,
+>                 "diagnostics": []
+>             },
+>             {
+>                 "category": "method",
+>                 "name": "torch.SymInt.__eq__",
+>                 "referenceCount": 1,
+>                 "isExported": true,
+>                 "isTypeKnown": true,
+>                 "isTypeAmbiguous": false,
+>                 "diagnostics": []
+>             },
+>             {
+>                 "category": "method",
+>                 "name": "torch.SymInt.__lt__",
+>                 "referenceCount": 1,
+>                 "isExported": true,
+>                 "isTypeKnown": true,
+>                 "isTypeAmbiguous": false,
+>                 "diagnostics": []
+>             },
+>             {
+>                 "category": "method",
+>                 "name": "torch.SymInt.__gt__",
+>                 "referenceCount": 1,
+>                 "isExported": true,
+>                 "isTypeKnown": true,
+>                 "isTypeAmbiguous": false,
+>                 "diagnostics": []
+12597c11858
+<                 "name": "torch.SymFloat.__sym_max__",
+---
+>                 "name": "torch.SymInt.__le__",
+12600c11861
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12602,12633c11863
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 698,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 698,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 698,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 698,
+<                                 "character": 19
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12637c11867
+<                 "name": "torch.SymFloat.__sym_min__",
+---
+>                 "name": "torch.SymInt.__ge__",
+12640c11870
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12642,12673c11872
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 701,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 701,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 701,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 701,
+<                                 "character": 19
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12677c11876
+<                 "name": "torch.SymFloat.__sym_int__",
+---
+>                 "name": "torch.SymInt.__add__",
+12680c11879
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12682,12698c11881
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 704,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 704,
+<                                 "character": 19
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12702c11885
+<                 "name": "torch.SymFloat.is_integer",
+---
+>                 "name": "torch.SymInt.__radd__",
+12705c11888
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12707,12723c11890
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 707,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 707,
+<                                 "character": 18
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12727c11894
+<                 "name": "torch.SymFloat.as_integer_ratio",
+---
+>                 "name": "torch.SymInt.__rmul__",
+12736c11903
+<                 "name": "torch.SymFloat.__repr__",
+---
+>                 "name": "torch.SymInt.__mod__",
+12739c11906
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12741,12757c11908
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 715,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 715,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12761c11912
+<                 "name": "torch.SymFloat.__hash__",
+---
+>                 "name": "torch.SymInt.__mul__",
+12764c11915
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12766,12782c11917
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 721,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 721,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12786c11921
+<                 "name": "torch.SymFloat.conjugate",
+---
+>                 "name": "torch.SymInt.__pow_by_natural__",
+12795c11930
+<                 "name": "torch.SymFloat.hex",
+---
+>                 "name": "torch.SymInt.__rpow_by_natural__",
+12803,12804c11938,11939
+<                 "category": "type variable",
+<                 "name": "torch.SymFloat.node",
+---
+>                 "category": "method",
+>                 "name": "torch.SymInt.__int_truediv__",
+12816c11951
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12818,12849c11953
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 548,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 548,
+<                                 "character": 24
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"SymFloat\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 548,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 548,
+<                                 "character": 24
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12856c11960
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12858,12889c11962
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 551,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 551,
+<                                 "character": 24
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"SymFloat\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 551,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 551,
+<                                 "character": 24
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12896c11969
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12898,12929c11971
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 554,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 554,
+<                                 "character": 25
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"SymFloat\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 554,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 554,
+<                                 "character": 25
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12936c11978
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12938,12969c11980
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 557,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 557,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 557,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 557,
+<                                 "character": 19
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+12976c11987
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+12978,13009c11989
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 560,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 560,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 560,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 560,
+<                                 "character": 19
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+13016c11996
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+13018,13034c11998
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 563,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 563,
+<                                 "character": 21
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+13041c12005
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+13043,13059c12007
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 566,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 566,
+<                                 "character": 15
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+13084c12032
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+13086,13102c12034
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 575,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 575,
+<                                 "character": 15
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+13109c12041
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+13111,13127c12043
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 578,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 578,
+<                                 "character": 14
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+13134c12050
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+13136,13152c12052
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 581,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 581,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+13186c12086
+<                                 "line": 603,
+---
+>                                 "line": 724,
+13190c12090
+<                                 "line": 603,
+---
+>                                 "line": 724,
+13211c12111
+<                                 "line": 610,
+---
+>                                 "line": 731,
+13215c12115
+<                                 "line": 610,
+---
+>                                 "line": 731,
+13223c12123
+<                 "category": "type variable",
+---
+>                 "category": "variable",
+13242c12142
+<                         "message": "Type of parameter \"other\" is partially unknown\n  Parameter type is \"Tensor | int | float | bool | complex | SymInt | SymFloat\"\n    Type argument 1 for class \"SymInt\" has unknown type\n    Type argument 1 for class \"SymFloat\" has unknown type",
+---
+>                         "message": "Type of parameter \"other\" is partially unknown\n  Parameter type is \"Tensor | int | float | bool | complex | SymInt | SymFloat\"",
+14934,14948d13833
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"storage_offset\" is partially unknown\n  Parameter type is \"int | SymInt | None\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 2972,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 2972,
+<                                 "character": 18
+<                             }
+<                         }
+<                     },
+14977,14991d13861
+<                         "message": "Type of parameter \"storage_offset\" is partially unknown\n  Parameter type is \"int | SymInt | None\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 2984,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 2984,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+15032,15046d13901
+<                         "message": "Type of parameter \"storage_offset\" is partially unknown\n  Parameter type is \"int | SymInt | None\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 2996,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 2996,
+<                                 "character": 26
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+15987,16001d14841
+<                         "range": {
+<                             "start": {
+<                                 "line": 3205,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 3205,
+<                                 "character": 16
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"minlength\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+16721,16735d15560
+<                         "message": "Type of parameter \"size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 3417,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 3417,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+19930,19944d18754
+<                         "message": "Type of parameter \"size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 4489,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 4489,
+<                                 "character": 14
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+20575c19385
+<                         "message": "Type of parameter \"other\" is partially unknown\n  Parameter type is \"Tensor | int | float | bool | SymInt | SymFloat\"\n    Type argument 1 for class \"SymInt\" has unknown type\n    Type argument 1 for class \"SymFloat\" has unknown type",
+---
+>                         "message": "Type of parameter \"other\" is partially unknown\n  Parameter type is \"Tensor | int | float | bool | SymInt | SymFloat\"",
+20630c19440
+<                         "message": "Type of parameter \"other\" is partially unknown\n  Parameter type is \"Tensor | int | float | bool | SymInt | SymFloat\"\n    Type argument 1 for class \"SymInt\" has unknown type\n    Type argument 1 for class \"SymFloat\" has unknown type",
+---
+>                         "message": "Type of parameter \"other\" is partially unknown\n  Parameter type is \"Tensor | int | float | bool | SymInt | SymFloat\"",
+24194,24208d23003
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"k\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 6059,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 6059,
+<                                 "character": 16
+<                             }
+<                         }
+<                     },
+24227,24241d23021
+<                         "message": "Type of parameter \"k\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 6059,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 6059,
+<                                 "character": 16
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+27487c26267
+<                         "message": "Type of parameter \"other\" is partially unknown\n  Parameter type is \"Tensor | int | float | bool | complex | SymInt | SymFloat\"\n    Type argument 1 for class \"SymInt\" has unknown type\n    Type argument 1 for class \"SymFloat\" has unknown type",
+---
+>                         "message": "Type of parameter \"other\" is partially unknown\n  Parameter type is \"Tensor | int | float | bool | complex | SymInt | SymFloat\"",
+27542c26322
+<                         "message": "Type of parameter \"other\" is partially unknown\n  Parameter type is \"Tensor | int | float | bool | complex | SymInt | SymFloat\"\n    Type argument 1 for class \"SymInt\" has unknown type\n    Type argument 1 for class \"SymFloat\" has unknown type",
+---
+>                         "message": "Type of parameter \"other\" is partially unknown\n  Parameter type is \"Tensor | int | float | bool | complex | SymInt | SymFloat\"",
+27579,27593d26358
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"num_samples\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 6898,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 6898,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+28138,28152d26902
+<                         "range": {
+<                             "start": {
+<                                 "line": 7085,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 7085,
+<                                 "character": 14
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"length\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+28182,28211d26931
+<                         "message": "Type of parameter \"start\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 7085,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 7085,
+<                                 "character": 14
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"length\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 7085,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 7085,
+<                                 "character": 14
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+28237,28266d26956
+<                         "message": "Type of parameter \"start\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 7097,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 7097,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"length\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 7097,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 7097,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+28546,28560d27235
+<                         "range": {
+<                             "start": {
+<                                 "line": 7235,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 7235,
+<                                 "character": 17
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+28680,28694d27354
+<                         "message": "Type of parameter \"size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 7447,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 7447,
+<                                 "character": 16
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+28760,28774d27419
+<                         "message": "Type of parameter \"size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 7587,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 7587,
+<                                 "character": 17
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+28902,28916d27546
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 7656,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 7656,
+<                                 "character": 22
+<                             }
+<                         }
+<                     },
+30626,30640d29255
+<                         "range": {
+<                             "start": {
+<                                 "line": 8339,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 8339,
+<                                 "character": 14
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"repeats\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+30695,30709d29309
+<                         "message": "Type of parameter \"output_size\" is partially unknown\n  Parameter type is \"int | SymInt | None\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 8385,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 8385,
+<                                 "character": 25
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+30725,30754d29324
+<                         "message": "Type of parameter \"repeats\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 8385,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 8385,
+<                                 "character": 25
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"output_size\" is partially unknown\n  Parameter type is \"int | SymInt | None\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 8385,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 8385,
+<                                 "character": 25
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+30820,30834d29389
+<                         "message": "Type of parameter \"shape\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 8450,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 8450,
+<                                 "character": 15
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+30901,30915d29455
+<                         "range": {
+<                             "start": {
+<                                 "line": 8530,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 8530,
+<                                 "character": 15
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+31109,31123d29648
+<                         "message": "Type of parameter \"shifts\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 8617,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 8617,
+<                                 "character": 12
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+32001,32015d30525
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"index\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9454,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9454,
+<                                 "character": 14
+<                             }
+<                         }
+<                     },
+32074,32088d30583
+<                         "message": "Type of parameter \"index\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9461,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9461,
+<                                 "character": 22
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+32115,32129d30609
+<                         "range": {
+<                             "start": {
+<                                 "line": 9500,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9500,
+<                                 "character": 12
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"storage_offset\" is partially unknown\n  Parameter type is \"int | SymInt\"",
+36237,36336d34716
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch._C.TensorBase.slice_inverse",
+<                 "referenceCount": 1,
+<                 "isExported": false,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "warning",
+<                         "message": "No docstring found for function \"torch._C.TensorBase.slice_inverse\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9663,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9663,
+<                                 "character": 21
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"src\" is partially unknown\n  Parameter type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9663,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9663,
+<                                 "character": 21
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"start\" is partially unknown\n  Parameter type is \"int | SymInt | None\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9663,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9663,
+<                                 "character": 21
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"end\" is partially unknown\n  Parameter type is \"int | SymInt | None\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9663,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9663,
+<                                 "character": 21
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"step\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9663,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9663,
+<                                 "character": 21
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"Tensor\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 9663,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 9663,
+<                                 "character": 21
+<                             }
+<                         }
+<                     }
+<                 ]
+36340c34720
+<                 "name": "torch._C.TensorBase.slice_scatter",
+---
+>                 "name": "torch._C.TensorBase.slice_inverse",
+36348,36349c34728,34729
+<                         "severity": "error",
+<                         "message": "Type of parameter \"src\" is partially unknown\n  Parameter type is \"Tensor\"",
+---
+>                         "severity": "warning",
+>                         "message": "No docstring found for function \"torch._C.TensorBase.slice_inverse\"",
+36352c34732
+<                                 "line": 9671,
+---
+>                                 "line": 9663,
+36356c34736
+<                                 "line": 9671,
+---
+>                                 "line": 9663,
+36364c34744
+<                         "message": "Type of parameter \"start\" is partially unknown\n  Parameter type is \"int | SymInt | None\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+---
+>                         "message": "Type of parameter \"src\" is partially unknown\n  Parameter type is \"Tensor\"",
+36367c34747
+<                                 "line": 9671,
+---
+>                                 "line": 9663,
+36371c34751
+<                                 "line": 9671,
+---
+>                                 "line": 9663,
+36379c34759
+<                         "message": "Type of parameter \"end\" is partially unknown\n  Parameter type is \"int | SymInt | None\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+---
+>                         "message": "Return type is partially unknown\n  Return type is \"Tensor\"",
+36382c34762
+<                                 "line": 9671,
+---
+>                                 "line": 9663,
+36386c34766
+<                                 "line": 9671,
+---
+>                                 "line": 9663,
+36390c34770,34780
+<                     },
+---
+>                     }
+>                 ]
+>             },
+>             {
+>                 "category": "method",
+>                 "name": "torch._C.TensorBase.slice_scatter",
+>                 "referenceCount": 1,
+>                 "isExported": false,
+>                 "isTypeKnown": false,
+>                 "isTypeAmbiguous": false,
+>                 "diagnostics": [
+36394c34784
+<                         "message": "Type of parameter \"step\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+---
+>                         "message": "Type of parameter \"src\" is partially unknown\n  Parameter type is \"Tensor\"",
+37366c35756
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+37368,37384c35758
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 10090,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 10090,
+<                                 "character": 22
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+37431c35805
+<                         "message": "Type of parameter \"other\" is partially unknown\n  Parameter type is \"Tensor | int | float | bool | complex | SymInt | SymFloat\"\n    Type argument 1 for class \"SymInt\" has unknown type\n    Type argument 1 for class \"SymFloat\" has unknown type",
+---
+>                         "message": "Type of parameter \"other\" is partially unknown\n  Parameter type is \"Tensor | int | float | bool | complex | SymInt | SymFloat\"",
+37486c35860
+<                         "message": "Type of parameter \"other\" is partially unknown\n  Parameter type is \"Tensor | int | float | bool | complex | SymInt | SymFloat\"\n    Type argument 1 for class \"SymInt\" has unknown type\n    Type argument 1 for class \"SymFloat\" has unknown type",
+---
+>                         "message": "Type of parameter \"other\" is partially unknown\n  Parameter type is \"Tensor | int | float | bool | complex | SymInt | SymFloat\"",
+37706,37720d36079
+<                         "message": "Type of parameter \"size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 10283,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 10283,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+38217,38231d36575
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"sections\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 10418,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 10418,
+<                                 "character": 20
+<                             }
+<                         }
+38261,38275d36604
+<                         "message": "Type of parameter \"dims\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 10438,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 10438,
+<                                 "character": 12
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+38611,38625d36939
+<                         "message": "Type of parameter \"k\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 11175,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 11175,
+<                                 "character": 12
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+39061c37375
+<                         "message": "Type of parameter \"other\" is partially unknown\n  Parameter type is \"Tensor | int | float | bool | SymInt | SymFloat\"\n    Type argument 1 for class \"SymInt\" has unknown type\n    Type argument 1 for class \"SymFloat\" has unknown type",
+---
+>                         "message": "Type of parameter \"other\" is partially unknown\n  Parameter type is \"Tensor | int | float | bool | SymInt | SymFloat\"",
+39116c37430
+<                         "message": "Type of parameter \"other\" is partially unknown\n  Parameter type is \"Tensor | int | float | bool | SymInt | SymFloat\"\n    Type argument 1 for class \"SymInt\" has unknown type\n    Type argument 1 for class \"SymFloat\" has unknown type",
+---
+>                         "message": "Type of parameter \"other\" is partially unknown\n  Parameter type is \"Tensor | int | float | bool | SymInt | SymFloat\"",
+39388c37702
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+39390,39406c37704
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"split_size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 11439,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 11439,
+<                                 "character": 20
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+39674,39688d37971
+<                         "message": "Type of parameter \"size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 11835,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 11835,
+<                                 "character": 12
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/__init__.pyi",
+<                         "severity": "error",
+53140,53424d51422
+<                 "category": "class",
+<                 "name": "torch.SymBool",
+<                 "referenceCount": 64,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [],
+<                 "alternateNames": [
+<                     "torch.types.SymBool"
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.SymBool.__init__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"node\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 743,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 743,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.SymBool.__bool__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 748,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 748,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.SymBool.__int__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 751,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 751,
+<                                 "character": 15
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.SymBool.__and__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 755,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 755,
+<                                 "character": 15
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.SymBool.__or__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 758,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 758,
+<                                 "character": 14
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.SymBool.__sym_not__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": []
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.SymBool.__sym_ite__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"then_val\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 781,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 781,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"else_val\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 781,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 781,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 781,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 781,
+<                                 "character": 19
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.SymBool.__eq__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type annotation for parameter \"other\" is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 784,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 784,
+<                                 "character": 14
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.SymBool.__repr__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 787,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 787,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.SymBool.__hash__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Return type annotation is missing",
+<                         "range": {
+<                             "start": {
+<                                 "line": 793,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 793,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "type variable",
+<                 "name": "torch.SymBool.node",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": []
+<             },
+<             {
+53438c51436
+<                                 "line": 801,
+---
+>                                 "line": 933,
+53442c51440
+<                                 "line": 801,
+---
+>                                 "line": 933,
+53453c51451
+<                                 "line": 801,
+---
+>                                 "line": 933,
+53457c51455
+<                                 "line": 801,
+---
+>                                 "line": 933,
+53478c51476
+<                                 "line": 818,
+---
+>                                 "line": 950,
+53482c51480
+<                                 "line": 818,
+---
+>                                 "line": 950,
+53493c51491
+<                                 "line": 818,
+---
+>                                 "line": 950,
+53497c51495
+<                                 "line": 818,
+---
+>                                 "line": 950,
+53518c51516
+<                                 "line": 833,
+---
+>                                 "line": 965,
+53522c51520
+<                                 "line": 833,
+---
+>                                 "line": 965,
+53533c51531
+<                                 "line": 833,
+---
+>                                 "line": 965,
+53537c51535
+<                                 "line": 833,
+---
+>                                 "line": 965,
+53558c51556
+<                                 "line": 848,
+---
+>                                 "line": 980,
+53562c51560
+<                                 "line": 848,
+---
+>                                 "line": 980,
+53573c51571
+<                                 "line": 848,
+---
+>                                 "line": 980,
+53577c51575
+<                                 "line": 848,
+---
+>                                 "line": 980,
+53588c51586
+<                                 "line": 848,
+---
+>                                 "line": 980,
+53592c51590
+<                                 "line": 848,
+---
+>                                 "line": 980,
+53613c51611
+<                                 "line": 893,
+---
+>                                 "line": 1025,
+53617c51615
+<                                 "line": 893,
+---
+>                                 "line": 1025,
+53628c51626
+<                                 "line": 893,
+---
+>                                 "line": 1025,
+53632c51630
+<                                 "line": 893,
+---
+>                                 "line": 1025,
+53643c51641
+<                                 "line": 893,
+---
+>                                 "line": 1025,
+53647c51645
+<                                 "line": 893,
+---
+>                                 "line": 1025,
+53668c51666
+<                                 "line": 912,
+---
+>                                 "line": 1044,
+53672c51670
+<                                 "line": 912,
+---
+>                                 "line": 1044,
+53683c51681
+<                                 "line": 912,
+---
+>                                 "line": 1044,
+53687c51685
+<                                 "line": 912,
+---
+>                                 "line": 1044,
+53708c51706
+<                                 "line": 971,
+---
+>                                 "line": 1103,
+53712c51710
+<                                 "line": 971,
+---
+>                                 "line": 1103,
+53733c51731
+<                                 "line": 975,
+---
+>                                 "line": 1107,
+53737c51735
+<                                 "line": 975,
+---
+>                                 "line": 1107,
+53748c51746
+<                                 "line": 975,
+---
+>                                 "line": 1107,
+53752c51750
+<                                 "line": 975,
+---
+>                                 "line": 1107,
+53763c51761
+<                                 "line": 975,
+---
+>                                 "line": 1107,
+53767c51765
+<                                 "line": 975,
+---
+>                                 "line": 1107,
+53778c51776
+<                                 "line": 975,
+---
+>                                 "line": 1107,
+53782c51780
+<                                 "line": 975,
+---
+>                                 "line": 1107,
+53803c51801
+<                                 "line": 986,
+---
+>                                 "line": 1118,
+53807c51805
+<                                 "line": 986,
+---
+>                                 "line": 1118,
+53818c51816
+<                                 "line": 986,
+---
+>                                 "line": 1118,
+53822c51820
+<                                 "line": 986,
+---
+>                                 "line": 1118,
+53833c51831
+<                                 "line": 986,
+---
+>                                 "line": 1118,
+53837c51835
+<                                 "line": 986,
+---
+>                                 "line": 1118,
+53903c51901
+<                                 "line": 1234,
+---
+>                                 "line": 1366,
+53907c51905
+<                                 "line": 1234,
+---
+>                                 "line": 1366,
+54142c52140
+<                                 "line": 1852,
+---
+>                                 "line": 1984,
+54146c52144
+<                                 "line": 1852,
+---
+>                                 "line": 1984,
+54400c52398
+<                                 "line": 1863,
+---
+>                                 "line": 1995,
+54404c52402
+<                                 "line": 1863,
+---
+>                                 "line": 1995,
+54450c52448
+<                                 "line": 1874,
+---
+>                                 "line": 2006,
+54454c52452
+<                                 "line": 1874,
+---
+>                                 "line": 2006,
+54500c52498
+<                                 "line": 1885,
+---
+>                                 "line": 2017,
+54504c52502
+<                                 "line": 1885,
+---
+>                                 "line": 2017,
+54550c52548
+<                                 "line": 1896,
+---
+>                                 "line": 2028,
+54554c52552
+<                                 "line": 1896,
+---
+>                                 "line": 2028,
+54600c52598
+<                                 "line": 1907,
+---
+>                                 "line": 2039,
+54604c52602
+<                                 "line": 1907,
+---
+>                                 "line": 2039,
+54650c52648
+<                                 "line": 1918,
+---
+>                                 "line": 2050,
+54654c52652
+<                                 "line": 1918,
+---
+>                                 "line": 2050,
+54700c52698
+<                                 "line": 1929,
+---
+>                                 "line": 2061,
+54704c52702
+<                                 "line": 1929,
+---
+>                                 "line": 2061,
+54750c52748
+<                                 "line": 1940,
+---
+>                                 "line": 2072,
+54754c52752
+<                                 "line": 1940,
+---
+>                                 "line": 2072,
+54800c52798
+<                                 "line": 1951,
+---
+>                                 "line": 2083,
+54804c52802
+<                                 "line": 1951,
+---
+>                                 "line": 2083,
+54850c52848
+<                                 "line": 1962,
+---
+>                                 "line": 2094,
+54854c52852
+<                                 "line": 1962,
+---
+>                                 "line": 2094,
+54900c52898
+<                                 "line": 1973,
+---
+>                                 "line": 2105,
+54904c52902
+<                                 "line": 1973,
+---
+>                                 "line": 2105,
+54950c52948
+<                                 "line": 1984,
+---
+>                                 "line": 2116,
+54954c52952
+<                                 "line": 1984,
+---
+>                                 "line": 2116,
+55000c52998
+<                                 "line": 1995,
+---
+>                                 "line": 2127,
+55004c53002
+<                                 "line": 1995,
+---
+>                                 "line": 2127,
+55050c53048
+<                                 "line": 2006,
+---
+>                                 "line": 2138,
+55054c53052
+<                                 "line": 2006,
+---
+>                                 "line": 2138,
+55100c53098
+<                                 "line": 2017,
+---
+>                                 "line": 2149,
+55104c53102
+<                                 "line": 2017,
+---
+>                                 "line": 2149,
+55150c53148
+<                                 "line": 2028,
+---
+>                                 "line": 2160,
+55154c53152
+<                                 "line": 2028,
+---
+>                                 "line": 2160,
+55202c53200
+<                                 "line": 2064,
+---
+>                                 "line": 2196,
+55206c53204
+<                                 "line": 2064,
+---
+>                                 "line": 2196,
+55217c53215
+<                                 "line": 2064,
+---
+>                                 "line": 2196,
+55221c53219
+<                                 "line": 2064,
+---
+>                                 "line": 2196,
+55232c53230
+<                                 "line": 2064,
+---
+>                                 "line": 2196,
+55236c53234
+<                                 "line": 2064,
+---
+>                                 "line": 2196,
+55247c53245
+<                                 "line": 2064,
+---
+>                                 "line": 2196,
+55251c53249
+<                                 "line": 2064,
+---
+>                                 "line": 2196,
+55262c53260
+<                                 "line": 2064,
+---
+>                                 "line": 2196,
+55266c53264
+<                                 "line": 2064,
+---
+>                                 "line": 2196,
+55277c53275
+<                                 "line": 2064,
+---
+>                                 "line": 2196,
+55281c53279
+<                                 "line": 2064,
+---
+>                                 "line": 2196,
+55292c53290
+<                                 "line": 2064,
+---
+>                                 "line": 2196,
+55296c53294
+<                                 "line": 2064,
+---
+>                                 "line": 2196,
+56178c54176
+<                                 "line": 2066,
+---
+>                                 "line": 2198,
+56182c54180
+<                                 "line": 2066,
+---
+>                                 "line": 2198,
+56212c54210
+<                                 "line": 2066,
+---
+>                                 "line": 2198,
+56216c54214
+<                                 "line": 2066,
+---
+>                                 "line": 2198,
+56227c54225
+<                                 "line": 2066,
+---
+>                                 "line": 2198,
+56231c54229
+<                                 "line": 2066,
+---
+>                                 "line": 2198,
+56261c54259
+<                                 "line": 2066,
+---
+>                                 "line": 2198,
+56265c54263
+<                                 "line": 2066,
+---
+>                                 "line": 2198,
+58407,58411d56404
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"storage_offset\" is partially unknown\n  Parameter type is \"int | SymInt | None\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+58441,58445d56433
+<                         "message": "Type of parameter \"storage_offset\" is partially unknown\n  Parameter type is \"int | SymInt | None\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+58466,58470d56453
+<                         "message": "Type of parameter \"storage_offset\" is partially unknown\n  Parameter type is \"int | SymInt | None\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+58501,58505d56483
+<                         "message": "Type of parameter \"storage_offset\" is partially unknown\n  Parameter type is \"int | SymInt | None\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+59441,59445d57418
+<                         "message": "Type of parameter \"minlength\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+60105,60109d58077
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+60865,60884d58832
+<                         "message": "Type of parameter \"stride\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"padding\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"dilation\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+60905,60919d58852
+<                         "message": "Type of parameter \"stride\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"dilation\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+60950,60969d58882
+<                         "message": "Type of parameter \"stride\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"padding\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"dilation\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+60990,61004d58902
+<                         "message": "Type of parameter \"stride\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"dilation\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+61031,61050d58928
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"stride\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"padding\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"dilation\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+61075,61089d58952
+<                         "message": "Type of parameter \"stride\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"dilation\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+61160,61184d59022
+<                         "message": "Type of parameter \"stride\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"padding\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"output_padding\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"dilation\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+61220,61244d59057
+<                         "message": "Type of parameter \"stride\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"padding\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"output_padding\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"dilation\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+61280,61304d59092
+<                         "message": "Type of parameter \"stride\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"padding\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"output_padding\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"dilation\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+61340,61344d59127
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+61836,61840d59618
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+61890,61894d59667
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+61930,61934d59702
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+61965,61969d59732
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+62890,62894d60652
+<                         "message": "Type of parameter \"padding_idx\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+62996,63000d60753
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+63472,63476d61224
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"n\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+63486,63490d61233
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"n\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+63495,63499d61237
+<                         "message": "Type of parameter \"m\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+66973,66977d64710
+<                         "message": "Type of parameter \"k\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+66993,66997d64725
+<                         "message": "Type of parameter \"k\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+69078,69082d66805
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+69123,69127d66845
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+69163,69167d66880
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+69203,69207d66915
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+69243,69247d66950
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+69348,69352d67050
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+69708,69712d67405
+<                         "message": "Type of parameter \"num_samples\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+70034,70038d67726
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"length\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+70053,70062d67740
+<                         "message": "Type of parameter \"start\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"length\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+70083,70092d67760
+<                         "message": "Type of parameter \"start\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"length\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+70168,70172d67835
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+70224,70238d67886
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"N\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"C\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"HxW\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+70524,70528d68171
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+70778,70782d68420
+<                         "message": "Type of parameter \"size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+72127,72131d69764
+<                         "message": "Type of parameter \"size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+72143,72147d69775
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"out\" is partially unknown\n  Parameter type is \"Tensor | None\""
+72152c69780
+<                         "message": "Return type is partially unknown\n  Return type is \"Tensor\""
+---
+>                         "message": "Type of parameter \"out\" is partially unknown\n  Parameter type is \"Tensor | None\""
+72157c69785
+<                         "message": "Type of parameter \"size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+---
+>                         "message": "Return type is partially unknown\n  Return type is \"Tensor\""
+72187,72191d69814
+<                         "message": "Type of parameter \"size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+72207,72211d69829
+<                         "message": "Type of parameter \"size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+72267,72271d69884
+<                         "message": "Type of parameter \"high\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+72287,72291d69899
+<                         "message": "Type of parameter \"high\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+72302,72311d69909
+<                         "message": "Type of parameter \"low\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"high\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+72327,72336d69924
+<                         "message": "Type of parameter \"low\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"high\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+72362,72371d69949
+<                         "message": "Type of parameter \"low\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"high\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+72397,72401d69974
+<                         "message": "Type of parameter \"high\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+72427,72431d69999
+<                         "message": "Type of parameter \"size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+72453,72457d70020
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+72487,72491d70049
+<                         "message": "Type of parameter \"size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+72507,72511d70064
+<                         "message": "Type of parameter \"size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+72544,72548d70096
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"n\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+72567,72571d70114
+<                         "message": "Type of parameter \"n\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+72842,72846d70384
+<                         "message": "Type of parameter \"output_size\" is partially unknown\n  Parameter type is \"int | SymInt | None\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+72853,72857d70390
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"output_size\" is partially unknown\n  Parameter type is \"int | SymInt | None\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+72872,72881d70404
+<                         "message": "Type of parameter \"repeats\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"output_size\" is partially unknown\n  Parameter type is \"int | SymInt | None\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+73252,73256d70774
+<                         "message": "Type of parameter \"shifts\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+73937,73941d71454
+<                         "message": "Type of parameter \"index\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+73972,73976d71484
+<                         "message": "Type of parameter \"index\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+74007,74011d71514
+<                         "message": "Type of parameter \"index\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+74353,74357d71855
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"start\" is partially unknown\n  Parameter type is \"int | SymInt | None\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+74362,74371d71859
+<                         "message": "Type of parameter \"end\" is partially unknown\n  Parameter type is \"int | SymInt | None\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"step\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+74407,74421d71894
+<                         "message": "Type of parameter \"start\" is partially unknown\n  Parameter type is \"int | SymInt | None\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"end\" is partially unknown\n  Parameter type is \"int | SymInt | None\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"step\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+74443,74447d71915
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"start\" is partially unknown\n  Parameter type is \"int | SymInt | None\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+74452,74461d71919
+<                         "message": "Type of parameter \"end\" is partially unknown\n  Parameter type is \"int | SymInt | None\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"step\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+74813,74817d72270
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"split_size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+75797,75801d73249
+<                         "message": "Type of parameter \"sections\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+75897,75901d73344
+<                         "message": "Type of parameter \"k\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+76418,76422d73860
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"split_size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+77072,77076d74509
+<                         "message": "Type of parameter \"size\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type"
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_C/_VariableFunctions.pyi",
+<                         "severity": "error",
+80833c78266
+<                                 "line": 2255,
+---
+>                                 "line": 2387,
+80837c78270
+<                                 "line": 2255,
+---
+>                                 "line": 2387,
+80997c78430
+<                                 "line": 2270,
+---
+>                                 "line": 2402,
+81001c78434
+<                                 "line": 2270,
+---
+>                                 "line": 2402,
+81022c78455
+<                                 "line": 2281,
+---
+>                                 "line": 2413,
+81026c78459
+<                                 "line": 2281,
+---
+>                                 "line": 2413,
+81037c78470
+<                                 "line": 2281,
+---
+>                                 "line": 2413,
+81041c78474
+<                                 "line": 2281,
+---
+>                                 "line": 2413,
+81052c78485
+<                                 "line": 2281,
+---
+>                                 "line": 2413,
+81056c78489
+<                                 "line": 2281,
+---
+>                                 "line": 2413,
+81067c78500
+<                                 "line": 2281,
+---
+>                                 "line": 2413,
+81071c78504
+<                                 "line": 2281,
+---
+>                                 "line": 2413,
+81092c78525
+<                                 "line": 2287,
+---
+>                                 "line": 2419,
+81096c78529
+<                                 "line": 2287,
+---
+>                                 "line": 2419,
+81117c78550
+<                                 "line": 2288,
+---
+>                                 "line": 2420,
+81121c78554
+<                                 "line": 2288,
+---
+>                                 "line": 2420,
+81151c78584
+<                                 "line": 2464,
+---
+>                                 "line": 2596,
+81155c78588
+<                                 "line": 2464,
+---
+>                                 "line": 2596,
+81166c78599
+<                                 "line": 2464,
+---
+>                                 "line": 2596,
+81170c78603
+<                                 "line": 2464,
+---
+>                                 "line": 2596,
+81227c78660
+<                                 "line": 2661,
+---
+>                                 "line": 2793,
+81231c78664
+<                                 "line": 2661,
+---
+>                                 "line": 2793,
+81242c78675
+<                                 "line": 2661,
+---
+>                                 "line": 2793,
+81246c78679
+<                                 "line": 2661,
+---
+>                                 "line": 2793,
+81267c78700
+<                                 "line": 2661,
+---
+>                                 "line": 2793,
+81271c78704
+<                                 "line": 2661,
+---
+>                                 "line": 2793,
+81282c78715
+<                                 "line": 2661,
+---
+>                                 "line": 2793,
+81286c78719
+<                                 "line": 2661,
+---
+>                                 "line": 2793,
+81297c78730
+<                                 "line": 2661,
+---
+>                                 "line": 2793,
+81301c78734
+<                                 "line": 2661,
+---
+>                                 "line": 2793,
+81312c78745
+<                                 "line": 2661,
+---
+>                                 "line": 2793,
+81316c78749
+<                                 "line": 2661,
+---
+>                                 "line": 2793,
+81337c78770
+<                                 "line": 2662,
+---
+>                                 "line": 2794,
+81341c78774
+<                                 "line": 2662,
+---
+>                                 "line": 2794,
+81352c78785
+<                                 "line": 2662,
+---
+>                                 "line": 2794,
+81356c78789
+<                                 "line": 2662,
+---
+>                                 "line": 2794,
+298283c295716
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+298285,298301c295718
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"int | SymInt\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 4666,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 4666,
+<                                 "character": 25
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+298308c295725
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+298310,298326c295727
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"float | SymFloat\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 4710,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 4710,
+<                                 "character": 27
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+298333c295734
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+298335,298351c295736
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"int | SymInt\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 4747,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 4747,
+<                                 "character": 44
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+298421c295806
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+298423,298439c295808
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 4761,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 4761,
+<                                 "character": 26
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+298446c295815
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+298448,298464c295817
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"SymFloat\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 4805,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 4805,
+<                                 "character": 32
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+298471c295824
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+298473,298489c295826
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"SymInt\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 4830,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 4830,
+<                                 "character": 30
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+298505c295842
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+298507,298523c295844
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 4859,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 4859,
+<                                 "character": 31
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+298536,298550d295856
+<                         "message": "Type of parameter \"val\" is partially unknown\n  Parameter type is \"int | SymInt | float | SymFloat\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 4884,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 4884,
+<                                 "character": 33
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+299090c296396
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+299092,299108c296398
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"SymInt | SymFloat | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 6024,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 6024,
+<                                 "character": 27
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+305389c302679
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+305396,305410d302685
+<                         "range": {
+<                             "start": {
+<                                 "line": 3145,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 3145,
+<                                 "character": 30
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_dynamo/output_graph.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"s\" is partially unknown\n  Parameter type is \"SymInt\"",
+309997c307272
+<                 "isTypeAmbiguous": false,
+---
+>                 "isTypeAmbiguous": true,
+310021c307296
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+310054c307329
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+310056,310072c307331
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_subclasses/fake_tensor.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"SymInt | SymFloat | None\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 597,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 597,
+<                                 "character": 15
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+310079c307338
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+310081,310097c307340
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_subclasses/fake_tensor.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"value\" is partially unknown\n  Parameter type is \"SymInt | SymFloat | None\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 619,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 619,
+<                                 "character": 15
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+310105c307348
+<                 "isTypeAmbiguous": false,
+---
+>                 "isTypeAmbiguous": true,
+310130c307373
+<                 "isTypeAmbiguous": false,
+---
+>                 "isTypeAmbiguous": true,
+310155c307398
+<                 "isTypeAmbiguous": false,
+---
+>                 "isTypeAmbiguous": true,
+310180c307423
+<                 "isTypeAmbiguous": false,
+---
+>                 "isTypeAmbiguous": true,
+310398c307641
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+310405,310434d307647
+<                         "range": {
+<                             "start": {
+<                                 "line": 978,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 978,
+<                                 "character": 22
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_subclasses/fake_tensor.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"coeff\" is partially unknown\n  Parameter type is \"int | SymInt\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 978,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 978,
+<                                 "character": 22
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_subclasses/fake_tensor.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"SymInt\"",
+310969c308182
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+310986,311000d308198
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/_subclasses/fake_tensor.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"SymInt\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 2887,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 2887,
+<                                 "character": 34
+<                             }
+<                         }
+350959,350973d348156
+<                         "range": {
+<                             "start": {
+<                                 "line": 257,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 257,
+<                                 "character": 18
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/proxy_tensor.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"obj\" is partially unknown\n  Parameter type is \"SymInt | SymFloat | SymBool\"",
+351036c348219
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+351045c348228
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+351063c348246
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+351065,351081c348248
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/proxy_tensor.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"key\" is partially unknown\n  Parameter type is \"SymInt | SymFloat | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1049,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1049,
+<                                 "character": 19
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+351149c348316
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+351151,351167c348318
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/proxy_tensor.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"key\" is partially unknown\n  Parameter type is \"SymInt | SymFloat | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1052,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1052,
+<                                 "character": 19
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+351174c348325
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+351176,351192c348327
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/proxy_tensor.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"key\" is partially unknown\n  Parameter type is \"SymInt | SymFloat | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1055,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1055,
+<                                 "character": 20
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+351199c348334
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+351206,351220d348340
+<                         "range": {
+<                             "start": {
+<                                 "line": 1058,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1058,
+<                                 "character": 11
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/proxy_tensor.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"key\" is partially unknown\n  Parameter type is \"SymInt | SymFloat | SymBool\"",
+351423,351437d348542
+<                         "range": {
+<                             "start": {
+<                                 "line": 1140,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1140,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/proxy_tensor.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"e\" is partially unknown\n  Parameter type is \"SymInt | SymFloat | SymBool\"",
+352051,352065d349155
+<                         "message": "Type of parameter \"obj\" is partially unknown\n  Parameter type is \"SymInt | SymFloat | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 386,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 386,
+<                                 "character": 18
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/proxy_tensor.py",
+<                         "severity": "error",
+352081,352095d349170
+<                         "message": "Type of parameter \"obj\" is partially unknown\n  Parameter type is \"SymInt | SymFloat | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 386,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 386,
+<                                 "character": 18
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/proxy_tensor.py",
+<                         "severity": "error",
+352111,352125d349185
+<                         "message": "Type of parameter \"obj\" is partially unknown\n  Parameter type is \"SymInt | SymFloat | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 386,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 386,
+<                                 "character": 18
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/proxy_tensor.py",
+<                         "severity": "error",
+352688,352717d349747
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/proxy_tensor.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"t\" is partially unknown\n  Parameter type is \"SymInt | SymFloat | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 784,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 784,
+<                                 "character": 22
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/proxy_tensor.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"Thunk[Proxy] | SymInt | SymFloat | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 784,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 784,
+<                                 "character": 22
+<                             }
+<                         }
+354542c351572
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+354610c351640
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+354617,354631d351646
+<                         "range": {
+<                             "start": {
+<                                 "line": 373,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 373,
+<                                 "character": 22
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/recording.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"int | SymInt\"",
+363009c360024
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+363018c360033
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+363027c360042
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+363029,363045c360044
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"val\" is partially unknown\n  Parameter type is \"SymInt | int\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 225,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 225,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+363168c360167
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+363202c360201
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+363204,363220c360203
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"a\" is partially unknown\n  Parameter type is \"SymInt | int\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 360,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 360,
+<                                 "character": 12
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+363227c360210
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+363236c360219
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+363253,363267d360235
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"a\" is partially unknown\n  Parameter type is \"SymInt | SymFloat | SymBool | int | float | bool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 375,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 375,
+<                                 "character": 12
+<                             }
+<                         }
+363276c360244
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+363278,363294c360246
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"a\" is partially unknown\n  Parameter type is \"int | SymInt\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 381,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 381,
+<                                 "character": 19
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+363301c360253
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+363303,363319c360255
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"a\" is partially unknown\n  Parameter type is \"float | SymFloat\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 401,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 401,
+<                                 "character": 21
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+363326c360262
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+363328,363344c360264
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"a\" is partially unknown\n  Parameter type is \"bool | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 420,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 420,
+<                                 "character": 20
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+363351c360271
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+363353,363369c360273
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"a\" is partially unknown\n  Parameter type is \"SymBool | SymFloat | SymInt | bool | float | int\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 442,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 442,
+<                                 "character": 20
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+363376c360280
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+363378,363394c360282
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"expr\" is partially unknown\n  Parameter type is \"SymBool | bool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 465,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 465,
+<                                 "character": 24
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+363533c360421
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+363540,363554d360427
+<                         "range": {
+<                             "start": {
+<                                 "line": 858,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 858,
+<                                 "character": 17
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"s\" is partially unknown\n  Parameter type is \"int | SymInt\"",
+364075c360948
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+364082,364115d360954
+<                     }
+<                 ]
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.fx.experimental.symbolic_shapes.ConvertIntKey.__str__",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": true,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": []
+<             },
+<             {
+<                 "category": "method",
+<                 "name": "torch.fx.experimental.symbolic_shapes.ConvertIntKey.get",
+<                 "referenceCount": 1,
+<                 "isExported": true,
+<                 "isTypeKnown": false,
+<                 "isTypeAmbiguous": false,
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"int | SymInt\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1046,
+<                                 "character": 8
+<                             },
+<                             "end": {
+<                                 "line": 1046,
+<                                 "character": 11
+<                             }
+<                         }
+364117a360957,360974
+>             },
+>             {
+>                 "category": "method",
+>                 "name": "torch.fx.experimental.symbolic_shapes.ConvertIntKey.__str__",
+>                 "referenceCount": 1,
+>                 "isExported": true,
+>                 "isTypeKnown": true,
+>                 "isTypeAmbiguous": false,
+>                 "diagnostics": []
+>             },
+>             {
+>                 "category": "method",
+>                 "name": "torch.fx.experimental.symbolic_shapes.ConvertIntKey.get",
+>                 "referenceCount": 1,
+>                 "isExported": true,
+>                 "isTypeKnown": true,
+>                 "isTypeAmbiguous": false,
+>                 "diagnostics": []
+364370c361227
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+364385c361242
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+364491c361348
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+364493,364509c361350
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"a\" is partially unknown\n  Parameter type is \"bool | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1397,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1397,
+<                                 "character": 18
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+364516c361357
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+364518,364534c361359
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"a\" is partially unknown\n  Parameter type is \"bool | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1404,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1404,
+<                                 "character": 17
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+364541c361366
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+364543,364559c361368
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"x\" is partially unknown\n  Parameter type is \"bool | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1429,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1429,
+<                                 "character": 26
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+364566c361375
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+364568,364584c361377
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"x\" is partially unknown\n  Parameter type is \"bool | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1452,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1452,
+<                                 "character": 25
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+364591c361384
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+364593,364639c361386
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"x\" is partially unknown\n  Parameter type is \"bool | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1473,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1473,
+<                                 "character": 11
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"others\" is partially unknown\n  Parameter type is \"bool | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1473,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1473,
+<                                 "character": 11
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"bool | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1473,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1473,
+<                                 "character": 11
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+364646c361393
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+364648,364664c361395
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"bool | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1484,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1484,
+<                                 "character": 10
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+364671c361402
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+364673,364719c361404
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"x\" is partially unknown\n  Parameter type is \"bool | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1499,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1499,
+<                                 "character": 10
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"others\" is partially unknown\n  Parameter type is \"bool | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1499,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1499,
+<                                 "character": 10
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"bool | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1499,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1499,
+<                                 "character": 10
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+364726c361411
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+364728,364744c361413
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"a\" is partially unknown\n  Parameter type is \"SymBool | SymInt | SymFloat | int | bool | float\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1510,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1510,
+<                                 "character": 16
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+364751c361420
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+364753,364769c361422
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"a\" is partially unknown\n  Parameter type is \"SymInt\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1607,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1607,
+<                                 "character": 19
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+364776c361429
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+364778,364809c361431
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"a\" is partially unknown\n  Parameter type is \"SymInt\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1653,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1653,
+<                                 "character": 19
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"b\" is partially unknown\n  Parameter type is \"SymInt\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1653,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1653,
+<                                 "character": 19
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+364816c361438
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+364833,364847d361454
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"a\" is partially unknown\n  Parameter type is \"bool | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1703,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1703,
+<                                 "character": 15
+<                             }
+<                         }
+364856c361463
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+364873,364887d361479
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"a\" is partially unknown\n  Parameter type is \"bool | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 1718,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1718,
+<                                 "character": 14
+<                             }
+<                         }
+364896c361488
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+364903,364917d361494
+<                         "range": {
+<                             "start": {
+<                                 "line": 1725,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1725,
+<                                 "character": 13
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"a\" is partially unknown\n  Parameter type is \"int | SymInt\"",
+364936c361513
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+364943,364957d361519
+<                         "range": {
+<                             "start": {
+<                                 "line": 1732,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 1732,
+<                                 "character": 15
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"a\" is partially unknown\n  Parameter type is \"float | SymFloat\"",
+365520c362082
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+365527,365541d362088
+<                         "range": {
+<                             "start": {
+<                                 "line": 2188,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 2188,
+<                                 "character": 15
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"val\" is partially unknown\n  Parameter type is \"int | SymInt | float | SymFloat | bool | SymBool\"",
+365644c362191
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+365646,365677c362193
+<                 "diagnostics": [
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"symbool\" is partially unknown\n  Parameter type is \"bool | SymBool\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 2467,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 2467,
+<                                 "character": 36
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/fx/experimental/symbolic_shapes.py",
+<                         "severity": "error",
+<                         "message": "Return type is partially unknown\n  Return type is \"int | SymInt\"",
+<                         "range": {
+<                             "start": {
+<                                 "line": 2467,
+<                                 "character": 4
+<                             },
+<                             "end": {
+<                                 "line": 2467,
+<                                 "character": 36
+<                             }
+<                         }
+<                     }
+<                 ]
+---
+>                 "diagnostics": []
+436915,436929d433430
+<                         "range": {
+<                             "start": {
+<                                 "line": 859,
+<                                 "character": 23
+<                             },
+<                             "end": {
+<                                 "line": 859,
+<                                 "character": 38
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+437000,437014d433500
+<                         "range": {
+<                             "start": {
+<                                 "line": 860,
+<                                 "character": 14
+<                             },
+<                             "end": {
+<                                 "line": 860,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"stride\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+437029,437073d433514
+<                         "message": "Type of parameter \"padding\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 860,
+<                                 "character": 14
+<                             },
+<                             "end": {
+<                                 "line": 860,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"dilation\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 860,
+<                                 "character": 14
+<                             },
+<                             "end": {
+<                                 "line": 860,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 860,
+<                                 "character": 14
+<                             },
+<                             "end": {
+<                                 "line": 860,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+437134,437178d433574
+<                         "message": "Type of parameter \"stride\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 860,
+<                                 "character": 14
+<                             },
+<                             "end": {
+<                                 "line": 860,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"dilation\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 860,
+<                                 "character": 14
+<                             },
+<                             "end": {
+<                                 "line": 860,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 860,
+<                                 "character": 14
+<                             },
+<                             "end": {
+<                                 "line": 860,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+437249,437308d433644
+<                         "message": "Type of parameter \"stride\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 861,
+<                                 "character": 14
+<                             },
+<                             "end": {
+<                                 "line": 861,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"padding\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 861,
+<                                 "character": 14
+<                             },
+<                             "end": {
+<                                 "line": 861,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"dilation\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 861,
+<                                 "character": 14
+<                             },
+<                             "end": {
+<                                 "line": 861,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 861,
+<                                 "character": 14
+<                             },
+<                             "end": {
+<                                 "line": 861,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+437355,437384d433690
+<                         "range": {
+<                             "start": {
+<                                 "line": 861,
+<                                 "character": 14
+<                             },
+<                             "end": {
+<                                 "line": 861,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"stride\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 861,
+<                                 "character": 14
+<                             },
+<                             "end": {
+<                                 "line": 861,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"dilation\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+437399,437413d433704
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 861,
+<                                 "character": 14
+<                             },
+<                             "end": {
+<                                 "line": 861,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+437470,437529d433760
+<                         "range": {
+<                             "start": {
+<                                 "line": 862,
+<                                 "character": 14
+<                             },
+<                             "end": {
+<                                 "line": 862,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"stride\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 862,
+<                                 "character": 14
+<                             },
+<                             "end": {
+<                                 "line": 862,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"padding\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 862,
+<                                 "character": 14
+<                             },
+<                             "end": {
+<                                 "line": 862,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"dilation\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 862,
+<                                 "character": 14
+<                             },
+<                             "end": {
+<                                 "line": 862,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+437604,437648d433834
+<                         "message": "Type of parameter \"stride\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 862,
+<                                 "character": 14
+<                             },
+<                             "end": {
+<                                 "line": 862,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"dilation\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 862,
+<                                 "character": 14
+<                             },
+<                             "end": {
+<                                 "line": 862,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 862,
+<                                 "character": 14
+<                             },
+<                             "end": {
+<                                 "line": 862,
+<                                 "character": 20
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+437819,437893d434004
+<                         "message": "Type of parameter \"stride\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 864,
+<                                 "character": 24
+<                             },
+<                             "end": {
+<                                 "line": 864,
+<                                 "character": 40
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"padding\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 864,
+<                                 "character": 24
+<                             },
+<                             "end": {
+<                                 "line": 864,
+<                                 "character": 40
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"output_padding\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 864,
+<                                 "character": 24
+<                             },
+<                             "end": {
+<                                 "line": 864,
+<                                 "character": 40
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 864,
+<                                 "character": 24
+<                             },
+<                             "end": {
+<                                 "line": 864,
+<                                 "character": 40
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"dilation\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 864,
+<                                 "character": 24
+<                             },
+<                             "end": {
+<                                 "line": 864,
+<                                 "character": 40
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+437965,438024d434075
+<                         "range": {
+<                             "start": {
+<                                 "line": 865,
+<                                 "character": 24
+<                             },
+<                             "end": {
+<                                 "line": 865,
+<                                 "character": 40
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"stride\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 865,
+<                                 "character": 24
+<                             },
+<                             "end": {
+<                                 "line": 865,
+<                                 "character": 40
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"padding\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 865,
+<                                 "character": 24
+<                             },
+<                             "end": {
+<                                 "line": 865,
+<                                 "character": 40
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"output_padding\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 865,
+<                                 "character": 24
+<                             },
+<                             "end": {
+<                                 "line": 865,
+<                                 "character": 40
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+438039,438053d434089
+<                         "message": "Type of parameter \"dilation\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 865,
+<                                 "character": 24
+<                             },
+<                             "end": {
+<                                 "line": 865,
+<                                 "character": 40
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+438125,438169d434160
+<                         "range": {
+<                             "start": {
+<                                 "line": 866,
+<                                 "character": 24
+<                             },
+<                             "end": {
+<                                 "line": 866,
+<                                 "character": 40
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"stride\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 866,
+<                                 "character": 24
+<                             },
+<                             "end": {
+<                                 "line": 866,
+<                                 "character": 40
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"padding\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 866,
+<                                 "character": 24
+<                             },
+<                             "end": {
+<                                 "line": 866,
+<                                 "character": 40
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"output_padding\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+438184,438213d434174
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 866,
+<                                 "character": 24
+<                             },
+<                             "end": {
+<                                 "line": 866,
+<                                 "character": 40
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"dilation\" is partially unknown\n  Parameter type is \"int | SymInt | Sequence[int | SymInt]\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+<                         "range": {
+<                             "start": {
+<                                 "line": 866,
+<                                 "character": 24
+<                             },
+<                             "end": {
+<                                 "line": 866,
+<                                 "character": 40
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+438395,438409d434355
+<                         "range": {
+<                             "start": {
+<                                 "line": 869,
+<                                 "character": 30
+<                             },
+<                             "end": {
+<                                 "line": 869,
+<                                 "character": 52
+<                             }
+<                         }
+<                     },
+<                     {
+<                         "file": "/Users/nenb/miniforge3/envs/pytorch-type-complete/lib/python3.11/site-packages/torch/__init__.py",
+<                         "severity": "error",
+<                         "message": "Type of parameter \"groups\" is partially unknown\n  Parameter type is \"int | SymInt\"\n    Type argument 1 for class \"SymInt\" has unknown type",
+504746c500692
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+504755c500701
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+504764c500710
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+504788c500734
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+504797c500743
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+504806c500752
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,
+504840c500786
+<                 "isTypeKnown": false,
+---
+>                 "isTypeKnown": true,

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -36,7 +36,7 @@ from typing_extensions import ParamSpec as _ParamSpec, TypeIs as _TypeIs
 
 
 if TYPE_CHECKING:
-    from .types import Device, IntLikeType
+    from .types import Device, IntLikeType, _bool, _int, _float, FloatLikeType, _str, BoolLikeType
 
 
 # As a bunch of torch.packages internally still have this check
@@ -422,58 +422,80 @@ class SymInt:
     in the symbolic shape workflow.
     """
 
-    def __init__(self, node):
+    def __init__(self, node: _Any) -> None:
         # This field MUST be named node; C++ binding code assumes that this
         # class has a field named node that stores SymNode
         self.node = node
 
-    def __bool__(self):
+    def __bool__(self) -> "_bool":
         return builtins.bool(self != 0)
 
-    def __int__(self):
+    def __int__(self) -> "_int":
         return self.node.int_()
 
-    def __index__(self):
+    def __index__(self) -> "_int":
         return self.node.int_()
 
     # Magic methods installed by torch.fx.experimental.sym_node
 
-    def __round__(self, ndigits=None):
+    def __round__(self, ndigits: "_int | None" = None) -> "SymInt":
         return self
 
-    def __truediv__(self, other):
+    def __truediv__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> "SymFloat":
         if isinstance(other, (builtins.float, SymFloat)):
             return sym_float(self).__float_truediv__(other)
         if not isinstance(other, (builtins.int, SymInt)):
             return NotImplemented
         return self.__int_truediv__(other)
 
-    def __rtruediv__(self, other):
+    def __rtruediv__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> "SymFloat":
         if isinstance(other, (builtins.float, SymFloat)):
             return sym_float(self).__rfloat_truediv__(other)
         if not isinstance(other, (builtins.int, SymInt)):
             return NotImplemented
         return self.__rint_truediv__(other)
+    
+    @_overload
+    def __floordiv__(self, other: "IntLikeType") -> "SymInt":
+        ...
+    @_overload
+    def __floordiv__(self, other: "FloatLikeType") -> "SymFloat":
+        ...
 
-    def __floordiv__(self, other):
+    def __floordiv__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymFloat", "SymInt"]:
         if isinstance(other, (builtins.float, SymFloat)):
             return sym_float(math.floor(sym_float(self) / other))
         if not isinstance(other, (builtins.int, SymInt)):
             return NotImplemented
         return self.__int_floordiv__(other)
+    
+    @_overload
+    def __rfloordiv__(self, other: "IntLikeType") -> "SymInt":
+        ...
+    @_overload
+    def __rfloordiv__(self, other: "FloatLikeType") -> "SymFloat":
+        ...
 
-    def __rfloordiv__(self, other):
+    # type ignore likely a bug in mypy, see https://github.com/python/mypy/issues/18498
+    def __rfloordiv__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymFloat", "SymInt"]: # type: ignore[misc]
         if isinstance(other, (builtins.float, SymFloat)):
             return sym_float(math.floor(other / sym_float(self)))
         if not isinstance(other, (builtins.int, SymInt)):
             return NotImplemented
         return self.__rint_floordiv__(other)
+    
+    @_overload
+    def __pow__(self, other: "IntLikeType") -> "SymInt":
+        ...
+    @_overload
+    def __pow__(self, other: "FloatLikeType") -> "SymFloat":
+        ...
 
     # nb: complex is impossible to handle correctly lol, with
     # negative base and integral float need to diverge semantics and
     # just always return complex.  Neener neener pretend this problem
     # doesn't exist
-    def __pow__(self, other):
+    def __pow__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]:
         if isinstance(other, (builtins.float, SymFloat)):
             return sym_float(self).__pow__(other)
         if not isinstance(other, (builtins.int, SymInt)):
@@ -497,7 +519,15 @@ class SymInt:
             #   }
             return sym_float(self).__pow__(sym_float(other))
 
-    def __rpow__(self, other):
+    @_overload
+    def __rpow__(self, other: "IntLikeType") -> "SymInt":
+        ...
+    @_overload
+    def __rpow__(self, other: "FloatLikeType") -> "SymFloat":
+        ...
+
+    # type ignore likely a bug in mypy, see https://github.com/python/mypy/issues/18498
+    def __rpow__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]: # type: ignore[misc]
         if isinstance(other, (builtins.float, SymFloat)):
             return sym_float(self).__rpow__(other)
         if not isinstance(other, (builtins.int, SymInt)):
@@ -507,85 +537,176 @@ class SymInt:
         else:
             return sym_float(self).__rpow__(sym_float(other))
 
-    def __eq__(self, other: object) -> builtins.bool:
+    def __eq__(self, other: _Any) -> "_bool":
         raise TypeError("type stub not overridden")
 
-    def __lt__(self, other) -> builtins.bool:
+    def __lt__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> "_bool":
         raise TypeError("type stub not overridden")
 
-    def __gt__(self, other) -> builtins.bool:
+    def __gt__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> "_bool":
         raise TypeError("type stub not overridden")
 
-    def __le__(self, other) -> builtins.bool:
+    def __le__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> "_bool":
         raise TypeError("type stub not overridden")
 
-    def __ge__(self, other) -> builtins.bool:
+    def __ge__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> "_bool":
         raise TypeError("type stub not overridden")
+    
+    @_overload
+    def __add__(self, other: "IntLikeType") -> "SymInt":
+        ...
+    @_overload
+    def __add__(self, other: "FloatLikeType") -> "SymFloat":
+        ...
 
-    def __add__(self, other) -> "SymInt":
+    def __add__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]:
         raise TypeError("type stub not overridden")
+    
+    @_overload
+    def __radd__(self, other: "IntLikeType") -> "SymInt":
+        ...
+    @_overload
+    def __radd__(self, other: "FloatLikeType") -> "SymFloat":
+        ...
 
-    def __radd__(self, other) -> "SymInt":
+    def __radd__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]:
         raise TypeError("type stub not overridden")
+    
+    @_overload
+    def __rmul__(self, other: "IntLikeType") -> "SymInt":
+        ...
+    @_overload
+    def __rmul__(self, other: "FloatLikeType") -> "SymFloat":
+        ...
 
-    def __rmul__(self, other) -> "SymInt":
+    def __rmul__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]:
         raise TypeError("type stub not overridden")
-
+    
+    @_overload
     def __mod__(self, other: "IntLikeType") -> "SymInt":
+        ...
+    @_overload
+    def __mod__(self, other: "FloatLikeType") -> "SymFloat":
+        ...
+
+    def __mod__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]:
         raise TypeError("type stub not overridden")
 
-    def __mul__(self, other) -> "SymInt":
+    @_overload
+    def __mul__(self, other: "IntLikeType") -> "SymInt":
+        ...
+    @_overload
+    def __mul__(self, other: "FloatLikeType") -> "SymFloat":
+        ...
+        
+    def __mul__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]:
+        raise TypeError("type stub not overridden")
+    
+    @_overload
+    def __pow_by_natural__(self, other: "IntLikeType") -> "SymInt":
+        ...
+    @_overload
+    def __pow_by_natural__(self, other: "FloatLikeType") -> "SymFloat":
+        ...
+
+    def __pow_by_natural__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> _Union["SymInt", "SymFloat"]:
         raise TypeError("type stub not overridden")
 
-    def __pow_by_natural__(self, other) -> "SymInt":
+    @_overload
+    def __rpow_by_natural__(self, other: "IntLikeType") -> "SymInt":
+        ...
+    @_overload
+    def __rpow_by_natural__(self, other: "FloatLikeType") -> "SymFloat":
+        ...
+
+    def __rpow_by_natural__(self, other:  _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]:
         raise TypeError("type stub not overridden")
 
-    def __rpow_by_natural__(self, other) -> "SymInt":
+    def __int_truediv__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
         raise TypeError("type stub not overridden")
 
-    def __int_truediv__(self, other) -> "SymFloat":
+    def __rint_truediv__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
+        raise TypeError("type stub not overridden")
+    
+    @_overload
+    def __int_floordiv__(self, other: "IntLikeType") -> "SymInt":
+        ...
+    @_overload
+    def __int_floordiv__(self, other: "FloatLikeType") -> "SymFloat":
+        ...
+
+    def __int_floordiv__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymFloat", "SymInt"]:
         raise TypeError("type stub not overridden")
 
-    def __rint_truediv__(self, other) -> "SymFloat":
+    @_overload
+    def __rint_floordiv__(self, other: "IntLikeType") -> "SymInt":
+        ...
+    @_overload
+    def __rint_floordiv__(self, other: "FloatLikeType") -> "SymFloat":
+        ...
+
+    def __rint_floordiv__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymFloat", "SymInt"]:
+        raise TypeError("type stub not overridden")
+    
+    @_overload
+    def __sym_max__(self, other: "IntLikeType") -> "SymInt":
+        ...
+    @_overload
+    def __sym_max__(self, other: "FloatLikeType") -> "SymFloat":
+        ...
+
+    def __sym_max__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]:
         raise TypeError("type stub not overridden")
 
-    def __int_floordiv__(self, other) -> "SymFloat":
+    @_overload
+    def __sym_min__(self, other: "IntLikeType") -> "SymInt":
+        ...
+    @_overload
+    def __sym_min__(self, other: "FloatLikeType") -> "SymFloat":
+        ...
+
+    def __sym_min__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]:
         raise TypeError("type stub not overridden")
 
-    def __rint_floordiv__(self, other) -> "SymFloat":
+    def __sym_float__(self) -> "SymFloat":
         raise TypeError("type stub not overridden")
 
-    def __sym_max__(self, other):
+    def __neg__(self) -> "SymInt":
         raise TypeError("type stub not overridden")
 
-    def __sym_min__(self, other):
-        raise TypeError("type stub not overridden")
-
-    def __sym_float__(self):
-        raise TypeError("type stub not overridden")
-
-    def __neg__(self):
-        raise TypeError("type stub not overridden")
-
+    @_overload
     def __sub__(self, other: "IntLikeType") -> "SymInt":
-        raise TypeError("type stub not overridden")
+        ...
+    @_overload
+    def __sub__(self, other: "FloatLikeType") -> "SymFloat":
+        ...
 
+    def __sub__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]:
+        raise TypeError("type stub not overridden")
+    
+    @_overload
     def __rsub__(self, other: "IntLikeType") -> "SymInt":
+        ...
+    @_overload
+    def __rsub__(self, other: "FloatLikeType") -> "SymFloat":
+        ...
+
+    def __rsub__(self, other: _Union["IntLikeType", "FloatLikeType"]) -> _Union["SymInt", "SymFloat"]:
         raise TypeError("type stub not overridden")
 
-    def __and__(self, other) -> "SymInt":
+    def __and__(self, other: _Union["IntLikeType", "_bool"]) -> "SymInt":
         raise TypeError("type stub not overridden")
 
-    def __or__(self, other) -> "SymInt":
+    def __or__(self, other: _Union["IntLikeType", "_bool"]) -> "SymInt":
         raise TypeError("type stub not overridden")
 
-    def __repr__(self):
+    def __repr__(self) -> "_str":
         return self.node._graph_repr()
 
-    def _sympy_(self):
+    def _sympy_(self) -> _Any:
         return self.node.expr
 
-    def __hash__(self) -> builtins.int:
+    def __hash__(self) -> "_int":
         if self.node.is_nested_int():
             return hash(self.node.nested_int())
         else:
@@ -597,11 +718,11 @@ class SymInt:
             # https://github.com/arogozhnikov/einops/blob/6181e1e95dc58c00a3143c1726da1c6ee0463164/einops/einops.py#L237
             # return hash(builtins.int(self))
 
-    def as_integer_ratio(self) -> tuple["SymInt", builtins.int]:
+    def as_integer_ratio(self) -> tuple["SymInt", "_int"]:
         """Represent this int as an exact integer ratio"""
         return self, 1
 
-    def bit_length(self) -> builtins.int:
+    def bit_length(self) -> "_int":
         # TODO: A more relaxed guard is possible here, where you guard to
         # allow all integer quantities which would result in the same bit
         # length.  We can also just make a dedicated Sympy function for
@@ -619,46 +740,46 @@ class SymFloat:
     in the symbolic shape workflow.
     """
 
-    def __init__(self, node):
+    def __init__(self, node: _Any) -> None:
         # This field MUST be named node; C++ binding code assumes that this
         # class has a field named node that stores SymNode
         self.node = node
 
-    def __truediv__(self, other):
+    def __truediv__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
         if not isinstance(other, (builtins.int, builtins.float, SymInt, SymFloat)):
             return NotImplemented
         return self.__float_truediv__(sym_float(other))
 
-    def __rtruediv__(self, other):
+    def __rtruediv__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
         if not isinstance(other, (builtins.int, builtins.float, SymInt, SymFloat)):
             return NotImplemented
         return self.__rfloat_truediv__(sym_float(other))
 
-    def __floordiv__(self, other):
+    def __floordiv__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
         if not isinstance(other, (builtins.int, builtins.float, SymInt, SymFloat)):
             return NotImplemented
         return sym_float(math.floor(self / sym_float(other)))
 
-    def __rfloordiv__(self, other):
+    def __rfloordiv__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
         if not isinstance(other, (builtins.int, builtins.float, SymInt, SymFloat)):
             return NotImplemented
         return sym_float(math.floor(sym_float(other) / self))
 
-    def __bool__(self):
+    def __bool__(self) -> "_bool":
         return self.node.bool_()
 
-    def __float__(self):
+    def __float__(self) -> "_float":
         return self.node.guard_float("", 0)
 
     # Symbolic power does NOT work with negative base, this is to avoid
     # potential complex outputs
-    def __pow__(self, other):
+    def __pow__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
         if not isinstance(other, (builtins.int, builtins.float, SymInt, SymFloat)):
             return NotImplemented
         torch._check(self >= 0)
         return self.__float_pow__(other)
 
-    def __rpow__(self, other):
+    def __rpow__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
         if not isinstance(other, (builtins.int, builtins.float, SymInt, SymFloat)):
             return NotImplemented
         torch._check(other >= 0)
@@ -666,67 +787,67 @@ class SymFloat:
 
     # Magic methods installed by torch.fx.experimental.sym_node
 
-    def __eq__(self, other: object) -> builtins.bool:
+    def __eq__(self, other: _Any) -> "_bool":
         raise TypeError("type stub not overridden")
 
-    def __lt__(self, other) -> builtins.bool:
+    def __lt__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "_bool":
         raise TypeError("type stub not overridden")
 
-    def __gt__(self, other) -> builtins.bool:
+    def __gt__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "_bool":
         raise TypeError("type stub not overridden")
 
-    def __le__(self, other) -> builtins.bool:
+    def __le__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "_bool":
         raise TypeError("type stub not overridden")
 
-    def __ge__(self, other) -> builtins.bool:
+    def __ge__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "_bool":
         raise TypeError("type stub not overridden")
 
-    def __float_pow__(self, other) -> "SymFloat":
+    def __float_pow__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
         raise TypeError("type stub not overridden")
 
-    def __rfloat_pow__(self, other) -> "SymFloat":
+    def __rfloat_pow__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
         raise TypeError("type stub not overridden")
 
-    def __float_truediv__(self, other) -> "SymFloat":
+    def __float_truediv__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
         raise TypeError("type stub not overridden")
 
-    def __rfloat_truediv__(self, other) -> "SymFloat":
+    def __rfloat_truediv__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
         raise TypeError("type stub not overridden")
 
-    def __trunc__(self):
+    def __trunc__(self) -> "SymInt":
         raise TypeError("type stub not overridden")
 
-    def __sym_max__(self, other):
+    def __sym_max__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
         raise TypeError("type stub not overridden")
 
-    def __sym_min__(self, other):
+    def __sym_min__(self, other: _Union["IntLikeType", "FloatLikeType", "_bool"]) -> "SymFloat":
         raise TypeError("type stub not overridden")
 
-    def __sym_int__(self):
+    def __sym_int__(self) -> "SymInt":
         raise TypeError("type stub not overridden")
 
-    def is_integer(self):
+    def is_integer(self) -> "SymBool":
         """Return True if the float is an integer."""
         raise TypeError("type stub not overridden")
 
-    def as_integer_ratio(self) -> tuple[builtins.int, builtins.int]:
+    def as_integer_ratio(self) -> tuple["_int", "_int"]:
         """Represent this float as an exact integer ratio"""
         return builtins.float(self).as_integer_ratio()
 
-    def __repr__(self):
+    def __repr__(self) -> "_str":
         return self.node._graph_repr()
 
-    def _sympy_(self):
+    def _sympy_(self) -> _Any:
         return self.node.expr
 
-    def __hash__(self):
+    def __hash__(self) -> "_int":
         return hash(builtins.float(self))
 
     def conjugate(self) -> "SymFloat":
         """Returns the complex conjugate of the float."""
         return self
 
-    def hex(self) -> str:
+    def hex(self) -> "_str":
         """Returns the hexadecimal representation of the float."""
         return self.node.guard_float("", 0).hex()
 
@@ -741,22 +862,22 @@ class SymBool:
     of symbolically evaluate.  Use the bitwise operators instead to handle this.
     """
 
-    def __init__(self, node):
+    def __init__(self, node: _Any) -> None:
         # This field MUST be named node; C++ binding code assumes that this
         # class has a field named node that stores SymNode
         self.node = node
 
-    def __bool__(self):
+    def __bool__(self) -> "_bool":
         return self.node.bool_()
 
-    def __int__(self):
+    def __int__(self) -> "_int":
         return builtins.int(self.node.bool_())
 
     # Magic methods installed by torch.fx.experimental.sym_node
-    def __and__(self, other) -> "SymBool":
+    def __and__(self, other: _Union["IntLikeType", "_bool"]) -> "SymBool":
         raise TypeError("type stub not overridden")
 
-    def __or__(self, other) -> "SymBool":
+    def __or__(self, other: _Union["IntLikeType", "_bool"]) -> "SymBool":
         raise TypeError("type stub not overridden")
 
     # We very carefully define __sym_not__, and not a number of other
@@ -779,19 +900,30 @@ class SymBool:
     def __sym_not__(self) -> "SymBool":
         raise TypeError("type stub not overridden")
 
-    def __sym_ite__(self, then_val, else_val):
+
+    # booleans behave like fixed-value ints in Python, type checker unable
+    # to handle separate overloads for booleans and ints as a result
+    @_overload
+    def __sym_ite__(self, then_val: _Union["IntLikeType", "BoolLikeType"], else_val: _Union["IntLikeType", "BoolLikeType"]) -> _Union["SymInt", "SymBool"]:
+        ...
+
+    @_overload
+    def __sym_ite__(self, then_val: "FloatLikeType", else_val: "FloatLikeType") -> "SymFloat":
+        ...
+
+    def __sym_ite__(self, then_val: _Union["IntLikeType", "FloatLikeType", "BoolLikeType"], else_val: _Union["IntLikeType", "FloatLikeType", "BoolLikeType"]) -> _Union["SymInt", "SymFloat", "SymBool"]:
         raise TypeError("type stub not overridden")
 
-    def __eq__(self, other) -> builtins.bool:
+    def __eq__(self, other: _Any) -> "_bool":
         raise TypeError("type stub not overridden")
 
-    def __repr__(self):
+    def __repr__(self) -> "_str":
         return self.node._graph_repr()
 
-    def _sympy_(self):
+    def _sympy_(self) -> _Any:
         return self.node.expr
 
-    def __hash__(self):
+    def __hash__(self) -> "_int":
         if self.node.is_constant():
             return hash(self.node.bool_())
         else:

--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -1080,7 +1080,7 @@ class DivideByKey:
     def __str__(self) -> str:
         return f".__floordiv__({self.divisor})"
 
-    def get(self, o: int) -> int:
+    def get(self, o: int) -> IntLikeType:
         """Divide object by divisor"""
         return o // self.divisor
 


### PR DESCRIPTION
This PR adds type annotations to the `Sym*` classes. This is required as `Sym*` are parameters for various methods on the `torch.Tensor` public interface.

------------------------

**Alternative Approach**

If it's not considered desirable to annotate the entire `Sym*` interface in this way for the public API, an alternative approach could be to agree on a minimal `Protocol` for representing the `Sym*` classes in the public API e.g.

```
from typing import Protocol, Any, SupportsInt, SupportsIndex

class SymIntLike(Protocol, SupportsInt, SupportsIndex):
    "A minimal description of a `SymInt` like object"
    node: Any

    def _sympy_(self) -> Any: ...
```
    